### PR TITLE
feat(wallet): unify gas estimation and simplify `WalletUser` trait

### DIFF
--- a/sdk/examples/13_send_amount.rs
+++ b/sdk/examples/13_send_amount.rs
@@ -32,13 +32,17 @@ async fn main() {
 
     // Send amount
     let amount = dec!(2.0).try_into().unwrap();
+    let data = Some("test".to_string().into_bytes());
+    // estimate gas
+    let estimate = sdk
+        .estimate_gas(&user.pin, &recipient_address, amount, data.clone())
+        .await
+        .unwrap();
+
+    println!("Estimated gas: {estimate:?}");
+
     let tx_id = sdk
-        .send_amount(
-            &user.pin,
-            &recipient_address,
-            amount,
-            Some("test".to_string().into_bytes()),
-        )
+        .send_amount(&user.pin, &recipient_address, amount, data)
         .await
         .unwrap();
 

--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -501,9 +501,9 @@ mod tests {
         let balance = wallet_user.get_balance().await.unwrap();
         println!("Address: {address}, balance: {balance:?}");
         let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
-
         let index = String::from("TestMessageFromStandalone");
-        let transaction = prepare_and_send_transaction(&wallet_user, &index, &address, amount)
+
+        let transaction = prepare_and_send_transaction(&wallet_user, &Some(index.into_bytes()), &address, amount)
             .await
             .unwrap();
 
@@ -534,7 +534,7 @@ mod tests {
         let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
 
         let index = String::from("TestMessageFromStandalone");
-        let transaction = prepare_and_send_transaction(&wallet_user, &index, &address, amount)
+        let transaction = prepare_and_send_transaction(&wallet_user, &Some(index.into_bytes()), &address, amount)
             .await
             .unwrap();
 
@@ -563,7 +563,7 @@ mod tests {
 
     #[cfg_attr(coverage, ignore = "Takes too long under code-coverage")]
     #[tokio::test]
-    async fn it_should_send_amount_with_tag_and_message() {
+    async fn it_should_send_amount_with_data() {
         // Arrange
         let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
@@ -573,9 +573,14 @@ mod tests {
 
         let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
         let message = Some(String::from("test message").into_bytes());
+        let intent = TransactionIntent {
+            address_to: address,
+            amount,
+            data: message,
+        };
 
         // Act
-        let result = wallet_user.send_amount(&address, amount, message.clone()).await;
+        let result = wallet_user.send_amount(&intent).await;
 
         // Assert
         let transaction = result.unwrap();
@@ -584,7 +589,7 @@ mod tests {
 
     #[cfg_attr(coverage, ignore = "Takes too long under code-coverage")]
     #[tokio::test]
-    async fn it_should_send_amount_without_tag_and_message() {
+    async fn it_should_send_amount_without_data() {
         // Arrange
         let (wallet_user, _cleanup) = get_wallet_user(MNEMONIC, Currency::Iota).await;
 
@@ -592,9 +597,14 @@ mod tests {
         let balance = wallet_user.get_balance().await.unwrap();
         println!("Address: {address}, balance: {balance:?}");
         let amount = CryptoAmount::try_from(balance.inner() - dec!(1.0)).unwrap();
+        let intent = TransactionIntent {
+            address_to: address,
+            amount,
+            data: None,
+        };
 
         // Act
-        let result = wallet_user.send_amount(&address, amount, None).await;
+        let result = wallet_user.send_amount(&intent).await;
 
         // Assert
         let transaction = result.unwrap();
@@ -610,9 +620,14 @@ mod tests {
         let balance = wallet_user.get_balance().await.unwrap();
         println!("Address: {address}, balance: {balance:?}");
         let amount = CryptoAmount::try_from(dec!(96854.0)).unwrap();
+        let intent = TransactionIntent {
+            address_to: address,
+            amount,
+            data: None,
+        };
 
         // Act
-        let transaction = wallet_user.send_amount(&address, amount, None).await;
+        let transaction = wallet_user.send_amount(&intent).await;
 
         // Assert
         assert!(

--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -232,13 +232,9 @@ impl WalletUser for WalletImplStardust {
 
         // Check if we have enough balance, otherwise return with err
         let balance = self.get_balance().await?;
-        println!("{balance:?}, {min_amount:?}");
         if balance < min_amount {
-            println!("d{balance:?}, {min_amount:?}");
             return Err(WalletError::InsufficientBalance(String::from("Not enough balance")));
         }
-
-        println!("Balance < amount + MIN_DUST_OUTPUT = {:?}", *amount + MIN_DUST_OUTPUT);
 
         // hard-coded tag
         let tag: Box<[u8]> = "data".to_string().into_bytes().into_boxed_slice();

--- a/sdk/src/wallet/wallet_user.rs
+++ b/sdk/src/wallet/wallet_user.rs
@@ -306,7 +306,12 @@ impl WalletUser for WalletImplStardust {
     }
 
     async fn estimate_gas_cost(&self, _intent: &TransactionIntent) -> Result<GasCostEstimation> {
-        Err(WalletError::WalletFeatureNotImplemented)
+        // Stardust is fee-less
+        Ok(GasCostEstimation {
+            gas_limit: 0,
+            max_fee_per_gas: 0,
+            max_priority_fee_per_gas: 0,
+        })
     }
 }
 

--- a/sdk/src/wallet/wallet_user_eth.rs
+++ b/sdk/src/wallet/wallet_user_eth.rs
@@ -123,7 +123,7 @@ impl WalletImplEth {
             data,
         } = intent;
 
-        let addr_to = Address::from_str(&address_to)?;
+        let addr_to = Address::from_str(address_to)?;
         let amount_wei = Self::convert_eth_to_wei(*amount);
         let amount_wei_u256 = Self::convert_crypto_amount_to_u256(amount_wei)?;
 
@@ -296,16 +296,12 @@ impl WalletImplEthErc20 {
             data,
         } = intent;
 
-        match data {
-            Some(data) if !data.is_empty() => {
-                // We cannot attach data to the smart contract transfer, so log a warning
-                log::warn!("Trying to attach data to an ERC20 Token transfer which will be ignored: {data:?}");
-                // TODO: should we return an error instead?
-            }
-            _ => {}
+        if data.as_ref().is_some_and(|d| !d.is_empty()) {
+            // We cannot attach data to the smart contract transfer, so log a warning
+            log::warn!("Trying to attach data to an ERC20 Token transfer which will be ignored: {data:?}");
         }
 
-        let addr_to = Address::from_str(&address_to)?;
+        let addr_to = Address::from_str(address_to)?;
         let amount_wei = WalletImplEth::convert_eth_to_wei(*amount);
         let amount_wei_u256 = WalletImplEth::convert_crypto_amount_to_u256(amount_wei)?;
 

--- a/sdk/src/wallet/wallet_user_eth.rs
+++ b/sdk/src/wallet/wallet_user_eth.rs
@@ -200,10 +200,6 @@ impl WalletUser for WalletImplEth {
         self.submit_transaction_request(tx_request).await
     }
 
-    async fn send_transaction(&self, _intent: &TransactionIntent) -> Result<String> {
-        unimplemented!("use send_amount");
-    }
-
     // The network does not provide information about historical transactions
     // (they can be retrieved manually, but this is a time-consuming process),
     // so the handling of this method is implemented at the SDK level.
@@ -342,10 +338,6 @@ impl WalletUser for WalletImplEthErc20 {
     async fn send_amount(&self, intent: &TransactionIntent) -> Result<String> {
         let tx_request = self.prepare_transaction(intent)?;
         self.inner.submit_transaction_request(tx_request).await
-    }
-
-    async fn send_transaction(&self, _intent: &TransactionIntent) -> Result<String> {
-        unimplemented!("use send_amount");
     }
 
     // The network does not provide information about historical transactions


### PR DESCRIPTION
## Motivation and Context

Explain why this change is necessary or the issue it addresses.

## Summary

Provide a short summary of changes in this pull request.

- Introduce type `TransactionIntent` to wrap all inputs related to performing a transaction. This struct is used as input for both `WalletUser::send_amount` and `WalletUser::estimate_gas_cost`. 
- Refactor EVM wallet impl to simplify and reuse logic across native and ERC20 transactions for both sending and gas estimation 💯 
- Simplify `WalletUser` trait by removing `send_transaction` (only used by Stardust wallet). We now always use `send_amount` and provide a relevant `TransactionIntent` 🔥 
- Add function `estimate_gas` to `Sdk` which can be used to estimate the gas for a transaction. 
   > Note: I have _not_ added any bindings as it felt like that might change anyways as we rework the wallet. Give a comment if you still think we should add bindings to this function here and I will do it 👍 

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [x] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
