### PR TITLE
feat(ci): create release for swift

### DIFF
--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -103,7 +103,7 @@ jobs:
           cd target-repo
           ls
           URL="https://github.com/${GH_REPO}/releases/download/nightly/ETOPaySdkBin.xcframework.zip"
-          sed -i '' -e "s|path: \"ETOPaySdkBin.xcframework\"|url: \"${URL}\", checksum: \"${CHECKSUM}\"|" Package.swift
+          sed -i -e "s|path: \"ETOPaySdkBin.xcframework\"|url: \"${URL}\", checksum: \"${CHECKSUM}\"|" Package.swift
           cat Package.swift
 
 

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           cd sdk/bindings/swift/ETOPaySdk
           ditto -c -k --sequesterRsrc --keepParent "ETOPaySdkBin.xcframework" "ETOPaySdkBin.xcframework.zip"
-          HASH=$(sha256sum -b ETOPaySdkBin.xcframework.zip | cut -d " " -f1)
+          HASH=$(shasum -a 256 "ETOPaySdkBin.xcframework.zip" | cut -d " " -f1)
           echo "hash=${HASH}" | tee -a $GITHUB_ENV
           rm -r ETOPaySdkBin.xcframework
 
@@ -100,9 +100,11 @@ jobs:
 
       - name: Modify url and insert hash
         run: |
+          cd target-repo
+          ls
           URL="https://github.com/${GH_REPO}/releases/download/nightly/ETOPaySdkBin.xcframework.zip"
-          sed -i '' -e "s|path: \"ETOPaySdkBin.xcframework\"|url: \"${URL}\", checksum: \"${CHECKSUM}\"|" target-repo/Package.swift
-          cat target-repo/Package.swift
+          sed -i '' -e "s|path: \"ETOPaySdkBin.xcframework\"|url: \"${URL}\", checksum: \"${CHECKSUM}\"|" Package.swift
+          cat Package.swift
 
 
       - name: Configure Git for commit

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -31,6 +31,7 @@ jobs:
     # provide outputs as input for the deploy step
     outputs:
       xcframework_sha256: ${{ steps.compress.outputs.hash }}
+      xcframework_filename: ${{ steps.compress.outputs.filename }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -57,9 +58,18 @@ jobs:
         id: compress
         run: |
           cd sdk/bindings/swift/ETOPaySdk
-          ditto -c -k --sequesterRsrc --keepParent "ETOPaySdkBin.xcframework" "ETOPaySdkBin.xcframework.zip"
-          HASH=$(shasum -a 256 "ETOPaySdkBin.xcframework.zip" | cut -d " " -f1)
+
+          # incorporate the short commit hash into the filename (to help with potential caching issues)
+          SHORT_SHA=$(git rev-parse --short ${{ github.sha }})
+          OUT_FILE="ETOPaySdkBin.xcframework-${SHORT_SHA}.zip"
+
+          ditto -c -k --sequesterRsrc --keepParent "ETOPaySdkBin.xcframework" ${OUT_FILE}
+
+          HASH=$(shasum -a 256 ${OUT_FILE} | cut -d " " -f1)
           echo "hash=${HASH}" | tee -a $GITHUB_OUTPUT
+          echo "filename=${OUT_FILE}" | tee -a $GITHUB_OUTPUT
+
+          # delete the folder so that it is not included in the uploaded artifact (include only the zip)
           rm -r ETOPaySdkBin.xcframework
 
       - name: Upload Artifact
@@ -80,6 +90,7 @@ jobs:
       GH_TOKEN: ${{ secrets.SWIFT_PAT_GITHUB_ACTIONS }}
       # get hash from previous job
       CHECKSUM: ${{ needs.build-sdk-swift.outputs.xcframework_sha256 }}
+      FILENAME: ${{ needs.build-sdk-swift.outputs.xcframework_filename }}
     steps:
       - name: Checkout target repository
         uses: actions/checkout@v4
@@ -101,11 +112,9 @@ jobs:
       - name: Modify url and insert hash
         run: |
           cd target-repo
-          ls
-          URL="https://github.com/${GH_REPO}/releases/download/nightly/ETOPaySdkBin.xcframework.zip"
+          URL="https://github.com/${GH_REPO}/releases/download/nightly/${FILENAME}"
           sed -i -e "s|path: \"ETOPaySdkBin.xcframework\"|url: \"${URL}\", checksum: \"${CHECKSUM}\"|" Package.swift
           cat Package.swift
-
 
       - name: Configure Git for commit
         run: |
@@ -132,4 +141,4 @@ jobs:
           DEBUG: api
         run: |
           cd target-repo
-          gh release create nightly --prerelease --title "nightly" ../artifacts/etopay-sdk-swift/ETOPaySdkBin.xcframework.zip
+          gh release create nightly --prerelease --title "nightly" ../artifacts/etopay-sdk-swift/${FILENAME}

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Build swift sdk
         run: |
           cd sdk/bindings/swift
-          make xcframework_mac
+          make xcframework
 
       - name: Compress xcframework
         id: compress

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -59,7 +59,7 @@ jobs:
           cd sdk/bindings/swift/ETOPaySdk
           ditto -c -k --sequesterRsrc --keepParent "ETOPaySdkBin.xcframework" "ETOPaySdkBin.xcframework.zip"
           HASH=$(shasum -a 256 "ETOPaySdkBin.xcframework.zip" | cut -d " " -f1)
-          echo "hash=${HASH}" | tee -a $GITHUB_ENV
+          echo "hash=${HASH}" | tee -a $GITHUB_OUTPUT
           rm -r ETOPaySdkBin.xcframework
 
       - name: Upload Artifact
@@ -132,4 +132,4 @@ jobs:
           DEBUG: api
         run: |
           cd target-repo
-          gh release create nightly --prerelease --title "nightly" artifacts/ETOPaySdkBin.xcframework.zip
+          gh release create nightly --prerelease --title "nightly" ../artifacts/ETOPaySdkBin.xcframework.zip

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -1,11 +1,19 @@
 name: deploy-swift
 
+# Re-Creates a release in the etopay-sdk-swift repo which has the xcframework zip file attached as release artifact
+# everytime it is run.
+# Inspired by the CI in `lapce`: https://github.com/lapce/lapce/blob/115bc731f52c6886481f63753d4db3c2985d7a95/.github/workflows/release.yml
+
 # only run this on push to main (eg. after PR merge)
 on:
   workflow_dispatch:
   push:
     branches:
       - main
+  pull_request:
+    paths:
+      # trigger release workflow only if this file changed
+      - .github/workflows/deploy-swift.yml
 
 env:
   CARGO_TERM_COLOR: always
@@ -20,6 +28,9 @@ concurrency:
 jobs:
   build-sdk-swift:
     runs-on: macos-latest
+    # provide outputs as input for the deploy step
+    outputs:
+      xcframework_sha256: ${{ steps.compress.outputs.hash }}
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -40,13 +51,22 @@ jobs:
       - name: Build swift sdk
         run: |
           cd sdk/bindings/swift
-          make xcframework
+          make xcframework_mac
+
+      - name: Compress xcframework
+        id: compress
+        run: |
+          cd sdk/bindings/swift/ETOPaySdk
+          ditto -c -k --sequesterRsrc --keepParent "ETOPaySdkBin.xcframework" "ETOPaySdkBin.xcframework.zip"
+          HASH=$(sha256sum -b ETOPaySdkBin.xcframework.zip | cut -d " " -f1)
+          echo "hash=${HASH}" | tee -a $GITHUB_ENV
+          rm -r ETOPaySdkBin.xcframework
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
           name: etopay-sdk-swift
-          path: sdk/bindings/swift/ETOPaySdk
+          path: sdk/bindings/swift/ETOPaySdk/
           if-no-files-found: error
           retention-days: 7
           overwrite: true
@@ -54,8 +74,12 @@ jobs:
   deploy-sdk-swift:
     runs-on: macos-latest
     needs: build-sdk-swift
-    # For now this does not work and just fails because the way it expects artifacts to be there. We need a better solution.
-    if: false
+    env:
+      # for gh CLI
+      GH_REPO: ETOSPHERES-Labs/etopay-sdk-swift
+      GH_TOKEN: ${{ secrets.SWIFT_PAT_GITHUB_ACTIONS }}
+      # get hash from previous job
+      CHECKSUM: ${{ needs.build-sdk-swift.outputs.has }}
     steps:
       - name: Checkout target repository
         uses: actions/checkout@v4
@@ -64,16 +88,27 @@ jobs:
           token: ${{ secrets.SWIFT_PAT_GITHUB_ACTIONS }}
           path: target-repo
 
-      - name: Copy built artifacts to target repository
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Copy artifact sources to target repository
         run: |
-          cp -R sdk/bindings/swift/ETOPaySdk/Package.swift target-repo/
-          cp -R sdk/bindings/swift/ETOPaySdk/README.md target-repo/
-          cp -R sdk/bindings/swift/ETOPaySdk/Sources target-repo/
+          cp -R artifacts/etopay-sdk-swift/Package.swift target-repo/
+          cp -R artifacts/etopay-sdk-swift/README.md target-repo/
+          cp -R artifacts/etopay-sdk-swift/Sources target-repo/
+
+      - name: Modify url and insert hash
+        run: |
+          URL="https://github.com/${GH_REPO}/releases/download/nightly/ETOPaySdkBin.xcframework.zip"
+          sed -i '' -e "s|path: \"ETOPaySdkBin.xcframework\"|url: \"${URL}\", checksum: \"${CHECKSUM}\"|" target-repo/Package.swift
+          cat target-repo/Package.swift
+
 
       - name: Configure Git for commit
         run: |
           cd target-repo
-          git config user.email "bot@etopay.com"
+          git config user.email "etopaybot@etoshpheres.com"
           git config user.name "bot"
 
       - name: Commit and push changes
@@ -82,3 +117,17 @@ jobs:
           git add .
           git commit -m "Update Swift SDK package files from commit ${{ github.sha }}" || echo "No changes to commit"
           git push
+
+      - name: Re-Tag nightly
+        run: |
+          cd target-repo
+          gh release delete nightly --yes || true
+          git push origin :nightly || true
+
+      - name: Publish release
+        # if: github.event_name != 'pull_request'
+        env:
+          DEBUG: api
+        run: |
+          cd target-repo
+          gh release create nightly --prerelease --title "nightly" artifacts/ETOPaySdk.xcframework.zip

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -79,7 +79,7 @@ jobs:
       GH_REPO: ETOSPHERES-Labs/etopay-sdk-swift
       GH_TOKEN: ${{ secrets.SWIFT_PAT_GITHUB_ACTIONS }}
       # get hash from previous job
-      CHECKSUM: ${{ needs.build-sdk-swift.outputs.has }}
+      CHECKSUM: ${{ needs.build-sdk-swift.outputs.hash }}
     steps:
       - name: Checkout target repository
         uses: actions/checkout@v4
@@ -132,4 +132,4 @@ jobs:
           DEBUG: api
         run: |
           cd target-repo
-          gh release create nightly --prerelease --title "nightly" ../artifacts/ETOPaySdkBin.xcframework.zip
+          gh release create nightly --prerelease --title "nightly" ../artifacts/etopay-sdk-swift/ETOPaySdkBin.xcframework.zip

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -79,7 +79,7 @@ jobs:
       GH_REPO: ETOSPHERES-Labs/etopay-sdk-swift
       GH_TOKEN: ${{ secrets.SWIFT_PAT_GITHUB_ACTIONS }}
       # get hash from previous job
-      CHECKSUM: ${{ needs.build-sdk-swift.outputs.hash }}
+      CHECKSUM: ${{ needs.build-sdk-swift.outputs.xcframework_sha256 }}
     steps:
       - name: Checkout target repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-swift.yml
+++ b/.github/workflows/deploy-swift.yml
@@ -72,7 +72,7 @@ jobs:
           overwrite: true
 
   deploy-sdk-swift:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: build-sdk-swift
     env:
       # for gh CLI
@@ -130,4 +130,4 @@ jobs:
           DEBUG: api
         run: |
           cd target-repo
-          gh release create nightly --prerelease --title "nightly" artifacts/ETOPaySdk.xcframework.zip
+          gh release create nightly --prerelease --title "nightly" artifacts/ETOPaySdkBin.xcframework.zip


### PR DESCRIPTION
## Motivation and Context

We wanted to push the Swift XCFramework to GitHub job artifacts, but turns out you need to be logged into GitHub to access those (which XCode is not...). So here is my attempt at (re)creating a nightly release in https://github.com/ETOSPHERES-Labs/etopay-sdk-swift/release and upload the artifacts there. After much trial and error it actually works! 💯 

Inspired by the workflow that creates nightly releases in https://github.com/lapce/lapce/releases


## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
