### PR TITLE
fix(dep): lock version of `deranged` to `v0.4.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1960,6 +1960,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "chrono",
+ "deranged",
  "dotenvy",
  "env_logger",
  "fake",

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -88,6 +88,12 @@ alloy-json-rpc = "0.12"
 alloy-transport = "0.12"
 shadow-rs = { version = "1.0.1", default-features = false }
 
+
+# Fix for version of `deranged` crate that got released while not being completely SemVer compatible
+# Without this our dependendts get the 0.4.1 version which makes iota-sdk not compile.
+# See: https://github.com/jhpratt/deranged/issues/18
+deranged = "=0.4.0"
+
 [dependencies.rusty_secrets]
 package = "rusty_secrets"
 git = "https://github.com/ETO-GRUPPE-TECHNOLOGIES-GmbH/RustySecrets.git"
@@ -139,4 +145,4 @@ required-features = ["viviswap-kyc"]
 
 # cargo-machete thinks that `alloy-consensus` is unused, but it is actually needed
 [package.metadata.cargo-machete]
-ignored = ["alloy-consensus"]
+ignored = ["alloy-consensus", "deranged"]


### PR DESCRIPTION
## Motivation and Context

Fix for version of `deranged` crate that got released while not being completely SemVer compatible...
Without this our dependents get the `0.4.1` version which makes `iota-sdk` not compile.
See: https://github.com/jhpratt/deranged/issues/18

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
