### PR TITLE
feat(api): introduce `Decimal` in `api_types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -734,8 +734,11 @@ name = "api_types"
 version = "0.14.0"
 dependencies = [
  "base64 0.22.1",
+ "rstest",
  "rust_decimal",
+ "rust_decimal_macros",
  "serde",
+ "serde_json",
  "utoipa",
 ]
 

--- a/api_types/Cargo.toml
+++ b/api_types/Cargo.toml
@@ -17,6 +17,11 @@ utoipa = { version = "5.3", default-features = false, features = [
     "macros",
 ], optional = true }
 
+[dev-dependencies]
+rstest = { workspace = true }
+serde_json = { workspace = true }
+rust_decimal_macros = { workspace = true }
+
 [features]
 # Enable to derive utoipa::{IntoParams, ToSchema} for the types.
 utoipa = ["dep:utoipa"]

--- a/api_types/Cargo.toml
+++ b/api_types/Cargo.toml
@@ -15,7 +15,6 @@ serde = { workspace = true }
 rust_decimal = { workspace = true }
 utoipa = { version = "5.3", default-features = false, features = [
     "macros",
-    "decimal",
 ], optional = true }
 
 [features]

--- a/api_types/src/api/decimal.rs
+++ b/api_types/src/api/decimal.rs
@@ -1,0 +1,61 @@
+/// Represents a decimal amount of either FIAT or crypto currencies, always in the main unit (eg.
+/// EURO, USD, ETH, IOTA).
+#[derive(Debug, Copy, Clone, PartialEq)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[cfg_attr(feature = "utoipa", schema(value_type = String))]
+pub struct Decimal(pub rust_decimal::Decimal);
+
+impl From<rust_decimal::Decimal> for Decimal {
+    fn from(value: rust_decimal::Decimal) -> Self {
+        Self(value)
+    }
+}
+
+/// Implementations of serde Serialize and Deserialize to make sure it is represented correctly
+/// as a String.
+mod serde {
+    use super::Decimal;
+
+    impl serde::Serialize for Decimal {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            serializer.serialize_str(&self.0.to_string())
+        }
+    }
+
+    struct DecimalVisitor;
+
+    impl serde::de::Visitor<'_> for DecimalVisitor {
+        type Value = Decimal;
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            formatter.write_str("String containing a decimal number")
+        }
+
+        fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+        where
+            E: serde::de::Error,
+        {
+            // This is the crucial part: using `from_str_exact` we make sure no rounding is
+            // implicitly performed. Instead, there will be an error if the number cannot be
+            // represented correctly.
+            //
+            // The built-in serialization uses `from_str` which applies truncation/rounding to fit
+            // which we do not want!
+            rust_decimal::Decimal::from_str_exact(v)
+                .map(Decimal)
+                .map_err(|e| E::custom(format!("Could not parse {v}: {e}")))
+        }
+    }
+
+    impl<'de> serde::Deserialize<'de> for Decimal {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where
+            D: serde::Deserializer<'de>,
+        {
+            deserializer.deserialize_string(DecimalVisitor)
+        }
+    }
+}

--- a/api_types/src/api/decimal.rs
+++ b/api_types/src/api/decimal.rs
@@ -59,3 +59,25 @@ mod serde {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::Decimal;
+    use rust_decimal_macros::dec;
+
+    #[rstest::rstest]
+    #[case("\"0.000000000000000001\"", Ok(Decimal::from(dec!(0.000000000000000001))))]
+    #[case("\"1.000000000000000001\"", Ok(Decimal::from(dec!(1.000000000000000001))))]
+    #[case("\"10000000000.000000000000000001\"", Ok(Decimal::from(dec!(10000000000.000000000000000001))))]
+    #[case("\"100000000000.000000000000000001\"", Err(serde_json::error::Category::Data))]
+    #[case("\"10000000000000000000000000001\"", Ok(Decimal::from(dec!(10000000000000000000000000001))))]
+    fn test_deserialization(#[case] input: &str, #[case] expected: Result<Decimal, serde_json::error::Category>) {
+        let result = serde_json::from_str::<Decimal>(input);
+
+        match (result, expected) {
+            (Ok(d), Ok(d2)) => assert_eq!(d, d2),
+            (Err(e), Err(e2)) => assert_eq!(e.classify(), e2),
+            (other, other2) => panic!("Expected: {:?} but got {:?}", other2, other),
+        }
+    }
+}

--- a/api_types/src/api/decimal.rs
+++ b/api_types/src/api/decimal.rs
@@ -1,5 +1,5 @@
-/// Represents a decimal amount of either FIAT or crypto currencies, always in the main unit (eg.
-/// EURO, USD, ETH, IOTA).
+/// Represents a decimal amount of either FIAT or crypto currencies, always in the main unit for
+/// respective currency/network (eg. EURO, USD, ETH, IOTA).
 #[derive(Debug, Copy, Clone, PartialEq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[cfg_attr(feature = "utoipa", schema(value_type = String))]

--- a/api_types/src/api/mod.rs
+++ b/api_types/src/api/mod.rs
@@ -1,6 +1,7 @@
 //! Contains shared objects used by requests-aggregator and the sdk for serialization and deserialization.
 //! Basically from the handlers.
 
+pub mod decimal;
 pub mod dlt;
 pub mod generic;
 pub mod kyc;

--- a/api_types/src/api/transactions/create.rs
+++ b/api_types/src/api/transactions/create.rs
@@ -1,5 +1,6 @@
+use crate::api::decimal::Decimal;
+
 use super::ApiApplicationMetadata;
-use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/api_types/src/api/transactions/details.rs
+++ b/api_types/src/api/transactions/details.rs
@@ -1,7 +1,7 @@
-use crate::api::networks::ApiNetwork;
+use crate::api::{decimal::Decimal, networks::ApiNetwork};
 
 use super::ApiTxStatus;
-use rust_decimal::Decimal;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/api_types/src/api/viviswap/contract.rs
+++ b/api_types/src/api/viviswap/contract.rs
@@ -1,5 +1,6 @@
-use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+
+use crate::api::decimal::Decimal;
 
 // data objects
 

--- a/api_types/src/api/viviswap/course.rs
+++ b/api_types/src/api/viviswap/course.rs
@@ -1,7 +1,6 @@
-use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
-use crate::api::generic::ApiCryptoCurrency;
+use crate::api::{decimal::Decimal, generic::ApiCryptoCurrency};
 
 // data objects
 

--- a/sdk/src/backend/transactions.rs
+++ b/sdk/src/backend/transactions.rs
@@ -69,7 +69,7 @@ pub async fn create_new_transaction(
     let url = format!("{base_url}/transactions/create");
 
     let body = CreateTransactionRequest {
-        amount: amount.inner(),
+        amount: amount.inner().into(),
         network_key,
         receiver: receiver.into(),
         application_metadata: metadata,
@@ -306,7 +306,7 @@ mod tests {
         let (mut srv, config, _cleanup) = set_config().await;
 
         let mock_request = CreateTransactionRequest {
-            amount: AMOUNT.inner(),
+            amount: AMOUNT.inner().into(),
             network_key: IOTA_NETWORK_KEY.to_string(),
             receiver: RECEIVER.into(),
             application_metadata: example_tx_metadata(),

--- a/sdk/src/backend/viviswap.rs
+++ b/sdk/src/backend/viviswap.rs
@@ -583,7 +583,7 @@ pub async fn set_viviswap_contract(
     info!("Set viviswap contract ");
 
     let request = ContractRequestBody {
-        amount: Option::Some(amount.inner()),
+        amount: Option::Some(amount.into()),
         incoming_payment_method_id,
         incoming_payment_detail_id,
         outgoing_payment_method_id,
@@ -1194,7 +1194,7 @@ mod tests {
         let (mut srv, config, _cleanup) = set_config().await;
 
         let mock_request = ContractRequestBody {
-            amount: Some(dec!(15.0)),
+            amount: Some(dec!(15.0).into()),
             incoming_payment_detail_id: Some(PAYMENT_DETAIL_ID.into()),
             incoming_payment_method_id: PAYMENT_METHOD_ID.into(),
             outgoing_payment_detail_id: PAYMENT_DETAIL_ID.into(),

--- a/sdk/src/backend/viviswap.rs
+++ b/sdk/src/backend/viviswap.rs
@@ -627,7 +627,7 @@ pub async fn get_viviswap_exchange_rate(
         .execute_parse()
         .await?;
 
-    Ok(response.course.course)
+    Ok(response.course.course.0)
 }
 
 /// Get viviswap payment methods.
@@ -1277,7 +1277,7 @@ mod tests {
         // Assert
         match expected {
             Ok(resp) => {
-                assert_eq!(response.unwrap(), resp.course.course);
+                assert_eq!(response.unwrap(), resp.course.course.0);
             }
             Err(ref expected_err) => {
                 assert_eq!(response.err().unwrap().to_string(), expected_err.to_string());

--- a/sdk/src/core/exchange.rs
+++ b/sdk/src/core/exchange.rs
@@ -48,7 +48,7 @@ mod tests {
     use rust_decimal::Decimal;
 
     #[rstest]
-    #[case::success(Ok(example_exchange_rate_response().course.course))]
+    #[case::success(Ok(example_exchange_rate_response().course.course.0))]
     #[case::repo_init_error(Err(crate::Error::UserRepoNotInitialized))]
     #[case::unauthorized(Err(crate::Error::MissingAccessToken))]
     #[case::missing_config(Err(crate::Error::MissingConfig))]

--- a/sdk/src/core/transaction.rs
+++ b/sdk/src/core/transaction.rs
@@ -101,7 +101,7 @@ impl Sdk {
 
         let details = PurchaseDetails {
             system_address: response.system_address,
-            amount: response.amount,
+            amount: response.amount.try_into()?,
             status: response.status,
             network: response.network,
         };
@@ -366,12 +366,12 @@ impl Sdk {
                         sender: val.incoming.username,
                         receiver: val.outgoing.username,
                         reference_id: val.index,
-                        amount: val.incoming.amount.try_into()?,
+                        amount: val.incoming.amount.0.try_into()?,
                         currency: val.incoming.network.display_symbol,
                         application_metadata: val.application_metadata,
                         status: val.status,
                         transaction_hash: val.incoming.transaction_id,
-                        course: val.incoming.exchange_rate.try_into()?,
+                        course: val.incoming.exchange_rate.0.try_into()?,
                     })
                 })
                 .collect::<Result<Vec<_>>>()?,
@@ -416,7 +416,7 @@ mod tests {
                 status: ApiTxStatus::Completed,
                 created_at: "2022-12-09T09:30:33.52Z".to_string(),
                 updated_at: "2022-12-09T09:30:33.52Z".to_string(),
-                fee_rate: dec!(0.2),
+                fee_rate: dec!(0.2).into(),
                 incoming: ApiTransferDetails {
                     transaction_id: Some(
                         "0x215322f8afdba4e22463a9d8a2e25d96ab0cb9ae6d56ee5ab13065068dae46c0".to_string(),
@@ -424,8 +424,8 @@ mod tests {
                     block_id: Some("0x215322f8afdba4e22463a9d8a2e25d96ab0cb9ae6d56ee5ab13065068dae46c0".to_string()),
                     username: "satoshi".into(),
                     address: main_address.clone(),
-                    amount: dec!(920.89),
-                    exchange_rate: dec!(0.06015),
+                    amount: dec!(920.89).into(),
+                    exchange_rate: dec!(0.06015).into(),
                     network: example_api_network(IOTA_NETWORK_KEY.to_string()),
                 },
                 outgoing: ApiTransferDetails {
@@ -435,8 +435,8 @@ mod tests {
                     block_id: Some("0x215322f8afdba4e22463a9d8a2e25d96ab0cb9ae6d56ee5ab13065068dae46c0".to_string()),
                     username: "hulk".into(),
                     address: aux_address.clone(),
-                    amount: dec!(920.89),
-                    exchange_rate: dec!(0.06015),
+                    amount: dec!(920.89).into(),
+                    exchange_rate: dec!(0.06015).into(),
                     network: example_api_network(IOTA_NETWORK_KEY.to_string()),
                 },
                 application_metadata: Some(example_tx_metadata()),
@@ -549,7 +549,7 @@ mod tests {
 
                 let mock_tx_response = GetTransactionDetailsResponse {
                     system_address: "".to_string(),
-                    amount: dec!(5.0),
+                    amount: dec!(5.0).into(),
                     status: ApiTxStatus::Valid,
                     network: example_api_network(IOTA_NETWORK_KEY.to_string()),
                 };
@@ -589,7 +589,7 @@ mod tests {
 
                 let mock_tx_response = GetTransactionDetailsResponse {
                     system_address: "".to_string(),
-                    amount: dec!(5.0),
+                    amount: dec!(5.0).into(),
                     status: ApiTxStatus::Invalid(vec!["ReceiverNotVerified".to_string()]),
                     network: example_api_network(IOTA_NETWORK_KEY.to_string()),
                 };
@@ -676,7 +676,7 @@ mod tests {
                 assert_eq!(
                     GetTransactionDetailsResponse {
                         system_address: response.as_ref().unwrap().system_address.clone(),
-                        amount: response.as_ref().unwrap().amount,
+                        amount: response.as_ref().unwrap().amount.into(),
                         status: response.unwrap().status,
                         network: example_api_network(IOTA_NETWORK_KEY.to_string()),
                     },

--- a/sdk/src/testing_utils.rs
+++ b/sdk/src/testing_utils.rs
@@ -159,7 +159,7 @@ pub fn example_tx_metadata() -> ApiApplicationMetadata {
 pub fn example_tx_details() -> GetTransactionDetailsResponse {
     GetTransactionDetailsResponse {
         system_address: ADDRESS.to_string(),
-        amount: AMOUNT.inner(),
+        amount: AMOUNT.inner().into(),
         status: ApiTxStatus::Completed,
         network: ApiNetwork {
             key: IOTA_NETWORK_KEY.to_string(),
@@ -296,7 +296,7 @@ pub fn example_get_payment_details_response() -> GetPaymentDetailsResponse {
 pub fn example_exchange_rate_response() -> GetCourseResponse {
     GetCourseResponse {
         course: Course {
-            course: dec!(1.0),
+            course: dec!(1.0).into(),
             date: "2222-22-22".into(),
         },
     }

--- a/sdk/src/types/currencies.rs
+++ b/sdk/src/types/currencies.rs
@@ -119,6 +119,19 @@ impl TryFrom<rust_decimal::Decimal> for CryptoAmount {
         Ok(Self(value))
     }
 }
+impl TryFrom<api_types::api::decimal::Decimal> for CryptoAmount {
+    type Error = crate::Error;
+
+    fn try_from(value: api_types::api::decimal::Decimal) -> std::result::Result<Self, Self::Error> {
+        Self::try_from(value.0)
+    }
+}
+
+impl From<CryptoAmount> for api_types::api::decimal::Decimal {
+    fn from(val: CryptoAmount) -> Self {
+        Self(val.0)
+    }
+}
 
 impl TryFrom<CryptoAmount> for f64 {
     type Error = crate::Error;

--- a/sdk/src/types/transactions.rs
+++ b/sdk/src/types/transactions.rs
@@ -7,8 +7,9 @@ use iota_sdk::{
     types::block::{helper::network_name_to_id, output::Output, payload::transaction::TransactionEssence},
     wallet::account::types::Transaction,
 };
-use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
+
+use super::currencies::CryptoAmount;
 
 /// Transaction list
 #[derive(Debug, Serialize)]
@@ -129,7 +130,7 @@ pub struct PurchaseDetails {
     /// The sender address where the fees goes to.
     pub system_address: String,
     /// The amount to be paid.
-    pub amount: Decimal,
+    pub amount: CryptoAmount,
     /// The status of transaction
     pub status: ApiTxStatus,
     /// The network that the transaction is sent in


### PR DESCRIPTION
## Motivation and Context

The default deserialization from `String` provided by `rust_decimal::Decimal` implicitly truncate/round the input if it does not fit within the number of bits. This means that a value of `10000000000000000000000000000.000000000000000001` would not cause an error, but rather be interpreted as `` which is not ideal.

To fix this we introduce `api_types::Decimal` that explicitly uses the `rust_decimal::Decimal::from_str_exact` function that returns an error if there are issues with Overflow / Underflow.

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [x] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
