### PR TITLE
fix: java library path and move Makefile for WASM examples

### DIFF
--- a/bindings/android/tests/build.gradle
+++ b/bindings/android/tests/build.gradle
@@ -76,7 +76,7 @@ task runCreateNewUser01(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runCreateNewWallet03(type: JavaExec) {
@@ -85,7 +85,7 @@ task runCreateNewWallet03(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runMigrateWalletFromMnemonic04(type: JavaExec) {
@@ -94,7 +94,7 @@ task runMigrateWalletFromMnemonic04(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runMigrateWalletFromBackup05(type: JavaExec) {
@@ -103,7 +103,7 @@ task runMigrateWalletFromBackup05(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runGenerateNewAddress06(type: JavaExec) {
@@ -112,7 +112,7 @@ task runGenerateNewAddress06(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runGetBalance07(type: JavaExec) {
@@ -121,7 +121,7 @@ task runGetBalance07(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runCreatePurchaseRequest08(type: JavaExec) {
@@ -130,7 +130,7 @@ task runCreatePurchaseRequest08(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runVerifyPin10(type: JavaExec) {
@@ -139,7 +139,7 @@ task runVerifyPin10(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runResetPin11(type: JavaExec) {
@@ -148,7 +148,7 @@ task runResetPin11(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runChangePassword12(type: JavaExec) {
@@ -157,7 +157,7 @@ task runChangePassword12(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runSendAmount13(type: JavaExec) {
@@ -166,7 +166,7 @@ task runSendAmount13(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runGetExchangeRate14(type: JavaExec) {
@@ -175,7 +175,7 @@ task runGetExchangeRate14(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runGetTxList16(type: JavaExec) {
@@ -184,7 +184,7 @@ task runGetTxList16(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runDeleteUser18(type: JavaExec) {
@@ -193,7 +193,7 @@ task runDeleteUser18(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runGetWalletTxList19(type: JavaExec) {
@@ -202,7 +202,7 @@ task runGetWalletTxList19(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runSendCompliment20(type: JavaExec) {
@@ -211,7 +211,7 @@ task runSendCompliment20(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 // examples that do not work 
@@ -222,7 +222,7 @@ task runOnboardUserPostident02 (type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runOnboardUserViviswap09(type: JavaExec) {
@@ -231,7 +231,7 @@ task runOnboardUserViviswap09(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     dependsOn compileNativeReleaseLibrary
 
-    systemProperty "java.library.path", file("../../../../target/release/")
+    systemProperty "java.library.path", file("../../../target/release/")
 }
 
 task runAllExamples(dependsOn: [

--- a/bindings/wasm/Makefile
+++ b/bindings/wasm/Makefile
@@ -1,0 +1,5 @@
+.phony: run_wasm_node_examples
+
+run_wasm_node_examples:
+	cd examples && chmod +x run_all_examples.sh && ./run_all_examples.sh
+

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -10,7 +10,4 @@ doc:
 run_rust_examples:
 	cd examples && chmod +x run_all_examples.sh && ./run_all_examples.sh
 
-run_wasm_node_examples:
-	cd ../bindings/wasm/examples && chmod +x run_all_examples.sh && ./run_all_examples.sh
-
-.phony: test build doc run_rust_examples run_wasm_node_examples
+.phony: test build doc run_rust_examples


### PR DESCRIPTION
## Motivation and Context

- Fix wrong path for java examples to find the native library.
- Move makefile command into WASM bindings where it belongs.

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
