### PR TITLE
chore(deps): bump `tokio` to `v1.44.2` to fix audit warning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5598,9 +5598,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",

--- a/deny.toml
+++ b/deny.toml
@@ -96,7 +96,6 @@ allow = [
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "ISC",
     "MPL-2.0",
     "CC0-1.0",


### PR DESCRIPTION
## Motivation and Context

Explain why this change is necessary or the issue it addresses.

## Summary

Provide a short summary of changes in this pull request.

- Update `tokio` to fix [RUSTSEC-2025-0023](https://rustsec.org/advisories/RUSTSEC-2025-0023).
- Remove unencountered license in `deny.toml` config.

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
