### PR TITLE
filtering using network_key

### DIFF
--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -14,6 +14,7 @@ use crate::{
     },
     wallet::error::{ErrorKind, WalletError},
 };
+use iota_sdk::wallet::account::types::InclusionState;
 use log::{debug, info, warn};
 
 impl Sdk {
@@ -497,6 +498,8 @@ impl Sdk {
         let user = self.get_user().await?;
         let wallet = self.try_get_active_user_wallet(pin).await?;
 
+        let inclusion_state_confirmed = format!("{:?}", InclusionState::Confirmed);
+
         let tx_list = match network.protocol {
             crate::types::networks::ApiProtocol::EvmERC20 {
                 chain_id: _,
@@ -514,6 +517,12 @@ impl Sdk {
                     .skip(start)
                     .take(limit)
                 {
+                    // We don't need to query the network for the state of this transaction,
+                    // because it has already been synchronized earlier (as indicated by `InclusionState::Confirmed`).
+                    if transaction.status == inclusion_state_confirmed {
+                        continue;
+                    }
+
                     let synchronized_transaction = wallet.get_wallet_tx(&transaction.transaction_id).await;
                     match synchronized_transaction {
                         Ok(stx) => *transaction = stx,
@@ -594,6 +603,7 @@ mod tests {
     };
     use api_types::api::dlt::SetUserAddressRequest;
     use api_types::api::viviswap::detail::SwapPaymentDetailKey;
+    use iota_sdk::wallet::account::types::InclusionState;
     use mockall::predicate::eq;
     use mockito::Matcher;
     use rstest::rstest;
@@ -1228,13 +1238,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_filtering_of_get_wallet_tx_list() {
+    async fn test_get_wallet_tx_list_filters_transactions_correctly() {
         // Arrange
         let (_srv, config, _cleanup) = set_config().await;
         let mut sdk = Sdk::new(config).unwrap();
 
-        // during the test we are expecting Status of WalletTxInfo.transaction_id = 2
-        // to change from `Waiting` to `Complete` after synchronization
+        // During the test, we expect the status of WalletTxInfo with transaction_id = 2
+        // to transition from 'Pending' to 'Confirmed' after synchronization
         let mixed_wallet_transactions = vec![
             WalletTxInfo {
                 date: "some date".to_string(),
@@ -1244,7 +1254,7 @@ mod tests {
                 incoming: true,
                 amount: 20.0,
                 network_key: "IOTA".to_string(),
-                status: "Complete".to_string(),
+                status: format!("{:?}", InclusionState::Confirmed),
                 explorer_url: None,
             },
             WalletTxInfo {
@@ -1255,7 +1265,7 @@ mod tests {
                 incoming: true,
                 amount: 1.0,
                 network_key: "ETH".to_string(),
-                status: "Waiting".to_string(),
+                status: format!("{:?}", InclusionState::Pending),
                 explorer_url: None,
             },
             WalletTxInfo {
@@ -1266,7 +1276,7 @@ mod tests {
                 incoming: true,
                 amount: 2.0,
                 network_key: "ETH".to_string(),
-                status: "Waiting".to_string(), // this one
+                status: format!("{:?}", InclusionState::Pending), // this one
                 explorer_url: None,
             },
             WalletTxInfo {
@@ -1277,7 +1287,7 @@ mod tests {
                 incoming: true,
                 amount: 3.0,
                 network_key: "ETH".to_string(),
-                status: "Waiting".to_string(),
+                status: format!("{:?}", InclusionState::Pending),
                 explorer_url: None,
             },
         ];
@@ -1306,7 +1316,7 @@ mod tests {
                 incoming: true,
                 amount: 20.0,
                 network_key: "IOTA".to_string(),
-                status: "Complete".to_string(),
+                status: format!("{:?}", InclusionState::Confirmed),
                 explorer_url: None,
             },
             WalletTxInfo {
@@ -1317,7 +1327,7 @@ mod tests {
                 incoming: true,
                 amount: 1.0,
                 network_key: "ETH".to_string(),
-                status: "Waiting".to_string(),
+                status: format!("{:?}", InclusionState::Pending),
                 explorer_url: None,
             },
             WalletTxInfo {
@@ -1328,7 +1338,7 @@ mod tests {
                 incoming: true,
                 amount: 2.0,
                 network_key: "ETH".to_string(),
-                status: "Complete".to_string(),
+                status: format!("{:?}", InclusionState::Confirmed),
                 explorer_url: None,
             },
             WalletTxInfo {
@@ -1339,7 +1349,7 @@ mod tests {
                 incoming: true,
                 amount: 3.0,
                 network_key: "ETH".to_string(),
-                status: "Waiting".to_string(),
+                status: format!("{:?}", InclusionState::Pending),
                 explorer_url: None,
             },
         ];
@@ -1371,7 +1381,7 @@ mod tests {
                         incoming: true,
                         amount: 2.0,
                         network_key: "ETH".to_string(),
-                        status: "Complete".to_string(), // Waiting -> Complete
+                        status: format!("{:?}", InclusionState::Confirmed), // Pending -> Confirmed
                         explorer_url: None,
                     })
                 });
@@ -1388,11 +1398,11 @@ mod tests {
 
         // Act
 
-        // We're requesting a single WalletTxInfo with get_wallet_tx_list(start = 1, limit = 1)
-        // We have [1 IOTA, 3 ETH] transactions stored
-        // Network key is ETH so we'll be searching through [3 ETH] transactions
-        // So we'll take this one:
-        // [WalletTxInfo{ ... }, -> WalletTxInfo{ id = 2 }, WalletTxInfo{ ... }]
+        // We request a single WalletTxInfo using get_wallet_tx_list(start = 1, limit = 1)
+        // We have stored transactions: [1 IOTA, 3 ETH]
+        // The network key is ETH, so we search through the 3 ETH transactions
+        // We select this one:
+        // [WalletTxInfo{ ... }, -> WalletTxInfo{ transaction_id = 2 }, WalletTxInfo{ ... }]
         let response = sdk.get_wallet_tx_list(&PIN, 1, 1).await;
 
         // Assert
@@ -1407,10 +1417,72 @@ mod tests {
                     incoming: true,
                     amount: 2.0,
                     network_key: "ETH".to_string(),
-                    status: "Complete".to_string(),
+                    status: format!("{:?}", InclusionState::Confirmed),
                     explorer_url: None,
                 }]
             }
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_wallet_tx_list_does_not_query_network_for_transaction_state() {
+        // Arrange
+        let (_srv, config, _cleanup) = set_config().await;
+        let mut sdk = Sdk::new(config).unwrap();
+
+        let wallet_transactions = vec![WalletTxInfo {
+            date: "some date".to_string(),
+            block_id: None,
+            transaction_id: "1".to_string(),
+            receiver: String::new(),
+            incoming: true,
+            amount: 1.0,
+            network_key: "ETH".to_string(),
+            status: format!("{:?}", InclusionState::Confirmed),
+            explorer_url: None,
+        }];
+
+        let mut mock_user_repo = MockUserRepo::new();
+        mock_user_repo.expect_get().returning(move |_| {
+            Ok(UserEntity {
+                user_id: None,
+                username: USERNAME.to_string(),
+                encrypted_password: Some(ENCRYPTED_PASSWORD.clone()),
+                salt: SALT.into(),
+                is_kyc_verified: false,
+                kyc_type: KycType::Undefined,
+                viviswap_state: None,
+                local_share: None,
+                wallet_transactions: wallet_transactions.clone(),
+            })
+        });
+
+        mock_user_repo
+            .expect_set_wallet_transactions()
+            .once()
+            .returning(|_, _| Ok(()));
+
+        sdk.repo = Some(Box::new(mock_user_repo));
+
+        let mut mock_wallet_manager = MockWalletManager::new();
+        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+            let mut mock_wallet_user = MockWalletUser::new();
+            mock_wallet_user.expect_get_wallet_tx().never();
+            Ok(WalletBorrow::from(mock_wallet_user))
+        });
+
+        sdk.active_user = Some(crate::types::users::ActiveUser {
+            username: USERNAME.into(),
+            wallet_manager: Box::new(mock_wallet_manager),
+        });
+
+        sdk.set_networks(example_api_networks());
+        sdk.set_network(ETH_NETWORK_KEY.to_string()).await.unwrap();
+
+        // Act
+        let response = sdk.get_wallet_tx_list(&PIN, 0, 1).await;
+
+        // Assert
+        assert!(response.is_ok())
     }
 }

--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -508,7 +508,12 @@ impl Sdk {
                 // and finally, save the refreshed list back to the wallet
                 let mut wallet_transactions = user.wallet_transactions;
 
-                for transaction in wallet_transactions.iter_mut().skip(start).take(limit) {
+                for transaction in wallet_transactions
+                    .iter_mut()
+                    .filter(|tx| tx.network_key == network.key)
+                    .skip(start)
+                    .take(limit)
+                {
                     let synchronized_transaction = wallet.get_wallet_tx(&transaction.transaction_id).await;
                     match synchronized_transaction {
                         Ok(stx) => *transaction = stx,
@@ -532,7 +537,17 @@ impl Sdk {
             api_types::api::networks::ApiProtocol::Stardust {} => wallet.get_wallet_tx_list(start, limit).await?,
         };
 
-        Ok(tx_list)
+        let tx_list_filtered = tx_list
+            .transactions
+            .into_iter()
+            .filter(|tx| tx.network_key == network.key)
+            .skip(start)
+            .take(limit)
+            .collect();
+
+        Ok(WalletTxInfoList {
+            transactions: tx_list_filtered,
+        })
     }
 
     /// wallet transaction
@@ -566,7 +581,8 @@ mod tests {
     use crate::core::core_testing_utils::handle_error_test_cases;
     use crate::testing_utils::{
         example_api_networks, example_get_user, example_wallet_tx_info, set_config, ADDRESS, AUTH_PROVIDER,
-        BACKUP_PASSWORD, HEADER_X_APP_NAME, IOTA_NETWORK_KEY, MNEMONIC, PIN, SALT, TOKEN, TX_INDEX, USERNAME,
+        BACKUP_PASSWORD, ENCRYPTED_PASSWORD, ETH_NETWORK_KEY, HEADER_X_APP_NAME, IOTA_NETWORK_KEY, MNEMONIC, PIN, SALT,
+        TOKEN, TX_INDEX, USERNAME,
     };
     use crate::types::users::UserEntity;
     use crate::{
@@ -578,6 +594,7 @@ mod tests {
     };
     use api_types::api::dlt::SetUserAddressRequest;
     use api_types::api::viviswap::detail::SwapPaymentDetailKey;
+    use mockall::predicate::eq;
     use mockito::Matcher;
     use rstest::rstest;
     use rust_decimal_macros::dec;
@@ -1208,5 +1225,192 @@ mod tests {
                 assert_eq!(response.err().unwrap().to_string(), expected_err.to_string());
             }
         }
+    }
+
+    #[tokio::test]
+    async fn test_filtering_of_get_wallet_tx_list() {
+        // Arrange
+        let (_srv, config, _cleanup) = set_config().await;
+        let mut sdk = Sdk::new(config).unwrap();
+
+        // during the test we are expecting Status of WalletTxInfo.transaction_id = 2
+        // to change from `Waiting` to `Complete` after synchronization
+        let mixed_wallet_transactions = vec![
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "some tx id".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 20.0,
+                network_key: "IOTA".to_string(),
+                status: "Complete".to_string(),
+                explorer_url: None,
+            },
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "1".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 1.0,
+                network_key: "ETH".to_string(),
+                status: "Waiting".to_string(),
+                explorer_url: None,
+            },
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "2".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 2.0,
+                network_key: "ETH".to_string(),
+                status: "Waiting".to_string(), // this one
+                explorer_url: None,
+            },
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "3".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 3.0,
+                network_key: "ETH".to_string(),
+                status: "Waiting".to_string(),
+                explorer_url: None,
+            },
+        ];
+
+        let mut mock_user_repo = MockUserRepo::new();
+        mock_user_repo.expect_get().returning(move |_| {
+            Ok(UserEntity {
+                user_id: None,
+                username: USERNAME.to_string(),
+                encrypted_password: Some(ENCRYPTED_PASSWORD.clone()),
+                salt: SALT.into(),
+                is_kyc_verified: false,
+                kyc_type: KycType::Undefined,
+                viviswap_state: None,
+                local_share: None,
+                wallet_transactions: mixed_wallet_transactions.clone(),
+            })
+        });
+
+        let mixed_wallet_transactions_after_synchronization = vec![
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "some tx id".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 20.0,
+                network_key: "IOTA".to_string(),
+                status: "Complete".to_string(),
+                explorer_url: None,
+            },
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "1".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 1.0,
+                network_key: "ETH".to_string(),
+                status: "Waiting".to_string(),
+                explorer_url: None,
+            },
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "2".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 2.0,
+                network_key: "ETH".to_string(),
+                status: "Complete".to_string(),
+                explorer_url: None,
+            },
+            WalletTxInfo {
+                date: "some date".to_string(),
+                block_id: None,
+                transaction_id: "3".to_string(),
+                receiver: String::new(),
+                incoming: true,
+                amount: 3.0,
+                network_key: "ETH".to_string(),
+                status: "Waiting".to_string(),
+                explorer_url: None,
+            },
+        ];
+
+        mock_user_repo
+            .expect_set_wallet_transactions()
+            .once()
+            .with(
+                eq(USERNAME.to_string()),
+                eq(mixed_wallet_transactions_after_synchronization.clone()),
+            )
+            .returning(|_, _| Ok(()));
+
+        sdk.repo = Some(Box::new(mock_user_repo));
+
+        let mut mock_wallet_manager = MockWalletManager::new();
+        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+            let mut mock_wallet_user = MockWalletUser::new();
+            mock_wallet_user
+                .expect_get_wallet_tx()
+                .once()
+                .with(eq(String::from("2"))) // WalletTxInfo.transaction_id = 2
+                .returning(move |_| {
+                    Ok(WalletTxInfo {
+                        date: "some date".to_string(),
+                        block_id: None,
+                        transaction_id: "2".to_string(),
+                        receiver: String::new(),
+                        incoming: true,
+                        amount: 2.0,
+                        network_key: "ETH".to_string(),
+                        status: "Complete".to_string(), // Waiting -> Complete
+                        explorer_url: None,
+                    })
+                });
+            Ok(WalletBorrow::from(mock_wallet_user))
+        });
+
+        sdk.active_user = Some(crate::types::users::ActiveUser {
+            username: USERNAME.into(),
+            wallet_manager: Box::new(mock_wallet_manager),
+        });
+
+        sdk.set_networks(example_api_networks());
+        sdk.set_network(ETH_NETWORK_KEY.to_string()).await.unwrap();
+
+        // Act
+
+        // We're requesting a single WalletTxInfo with get_wallet_tx_list(start = 1, limit = 1)
+        // We have [1 IOTA, 3 ETH] transactions stored
+        // Network key is ETH so we'll be searching through [3 ETH] transactions
+        // So we'll take this one:
+        // [WalletTxInfo{ ... }, -> WalletTxInfo{ id = 2 }, WalletTxInfo{ ... }]
+        let response = sdk.get_wallet_tx_list(&PIN, 1, 1).await;
+
+        // Assert
+        assert_eq!(
+            response.unwrap(),
+            WalletTxInfoList {
+                transactions: vec![WalletTxInfo {
+                    date: "some date".to_string(),
+                    block_id: None,
+                    transaction_id: "2".to_string(),
+                    receiver: String::new(),
+                    incoming: true,
+                    amount: 2.0,
+                    network_key: "ETH".to_string(),
+                    status: "Complete".to_string(),
+                    explorer_url: None,
+                }]
+            }
+        );
     }
 }

--- a/sdk/src/testing_utils.rs
+++ b/sdk/src/testing_utils.rs
@@ -30,6 +30,7 @@ use api_types::api::{
         payment::{ViviPaymentMethod, ViviPaymentMethodsResponse},
     },
 };
+use iota_sdk::wallet::account::types::InclusionState;
 use mockito::{Server, ServerOpts};
 use rust_decimal_macros::dec;
 use std::sync::LazyLock;
@@ -359,7 +360,7 @@ pub fn example_wallet_tx_info() -> WalletTxInfo {
         incoming: true,
         amount: 20.0,
         network_key: "IOTA".to_string(),
-        status: "Complete".to_string(),
+        status: format!("{:?}", InclusionState::Confirmed),
         explorer_url: None,
     }
 }

--- a/sdk/src/testing_utils.rs
+++ b/sdk/src/testing_utils.rs
@@ -358,7 +358,7 @@ pub fn example_wallet_tx_info() -> WalletTxInfo {
         receiver: String::new(),
         incoming: true,
         amount: 20.0,
-        network_key: "some network".to_string(),
+        network_key: "IOTA".to_string(),
         status: "Complete".to_string(),
         explorer_url: None,
     }


### PR DESCRIPTION
## Motivation and Context

- transactions are now filtered using the active network (its network_key)
- if a transaction has a status `Confirmed`, we don't fetch it from the crypto network for synchronization (nothing will change in it anyway)


## Summary

Provide a short summary of changes in this pull request.

- Change 1
- Change 2

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
