### PR TITLE
fix: do not push address if purchases are not supported

### DIFF
--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -441,7 +441,9 @@ impl Sdk {
 
         // if there is an access token, push the generated address to the backend
         if let Some(access_token) = self.access_token.as_ref() {
-            put_user_address(config, access_token, network.key, &address).await?;
+            if network.can_do_purchases {
+                put_user_address(config, access_token, network.key, &address).await?;
+            }
         }
         debug!("Generated address: {address}");
         Ok(address)


### PR DESCRIPTION
## Motivation and Context

We were always pushing the address, even if purchases are not supported by the network. This caused an error since the backend returns 500 Internal Server error for this. Changed so that we only try to push it whenever `can_do_purchases` is true for the network 💯 

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [x] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
