### PR TITLE
feat(iota): consolidate coins

### DIFF
--- a/sdk/src/wallet/rebased/rpc/coin.rs
+++ b/sdk/src/wallet/rebased/rpc/coin.rs
@@ -15,10 +15,10 @@ use jsonrpsee::proc_macros::rpc;
 use serde::Deserialize;
 use serde_with::serde_as;
 
-use super::super::ObjectID;
 use super::super::bigint::BigInt;
 use super::super::serde::SequenceNumber as AsSequenceNumber;
 use super::super::types::{IotaAddress, ObjectDigest, SequenceNumber, TransactionDigest};
+use super::super::{ObjectID, ObjectRef};
 
 /// Provides access to coin-related data such as coins owned by an address,
 /// balances, or metadata.
@@ -76,6 +76,12 @@ pub struct Coin {
     #[serde_as(as = "BigInt<u64>")]
     pub balance: u64,
     pub previous_transaction: TransactionDigest,
+}
+
+impl Coin {
+    pub fn obj_ref(&self) -> ObjectRef {
+        (self.coin_object_id, self.version, self.digest)
+    }
 }
 
 #[serde_as]


### PR DESCRIPTION
## Motivation and Context

> This builds on #156 

Whenever we perform a transaction on IOTA Rebased, we currently need to split a coin object and send it away. This means that you can easily end up owning multiple coin objects which together have a high balance, but each separately is not enough to cover your intended transaction.

To fix that, this PR adds logic that will merge multiple existing coins into the `GasCoin` before performing the split 💯 


## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
