### PR TITLE
fix: allow large error size, change unsafe annotation placement

### DIFF
--- a/bindings/android/src/lib.rs
+++ b/bindings/android/src/lib.rs
@@ -56,11 +56,10 @@ fn runtime() -> &'static Arc<Runtime> {
 /// The sdk handle with atomic reference counter as a static reference
 fn get_or_init_sdk() -> &'static SdkWrapper {
     static CELL: OnceCell<SdkWrapper> = OnceCell::new();
-    let sdk = CELL.get_or_init(|| {
+    CELL.get_or_init(|| {
         let sdk_user = Sdk::default();
         Arc::new(RwLock::new(sdk_user))
-    });
-    sdk
+    })
 }
 
 /// Main object that contains all the functionality for interfacing with the ETOPaySdk.

--- a/sdk/src/core/config.rs
+++ b/sdk/src/core/config.rs
@@ -100,6 +100,7 @@ impl TryFrom<DeserializedConfig> for Config {
 
 impl Config {
     /// Load the [`Config`] directly from a JSON-formatted [`String`] or [`str`].
+    #[allow(clippy::result_large_err)]
     pub fn from_json(json: impl AsRef<str>) -> Result<Self> {
         let json = json.as_ref();
         let deserialized_config: DeserializedConfig = json.parse()?;
@@ -109,6 +110,7 @@ impl Config {
 
 impl Sdk {
     /// Set the [`Config`] needed by the SDK
+    #[allow(clippy::result_large_err)]
     pub fn set_config(&mut self, config: Config) -> Result<()> {
         info!("Setting config: {config:?}");
         // TODO: do any destructing things if config already exists
@@ -132,6 +134,7 @@ impl Sdk {
     }
 
     /// Set path prefix
+    #[allow(clippy::result_large_err)]
     fn initialize_user_repository(&mut self) -> Result<()> {
         // initialize jammdb
         #[cfg(feature = "jammdb_repo")]

--- a/sdk/src/core/mod.rs
+++ b/sdk/src/core/mod.rs
@@ -79,6 +79,7 @@ impl Default for Sdk {
 
 impl Sdk {
     /// Initialize an SDK instance from a config
+    #[allow(clippy::result_large_err)]
     pub fn new(config: Config) -> Result<Self> {
         debug!("Configuration: {:?}", config);
         let mut s = Self::default();

--- a/sdk/src/logger.rs
+++ b/sdk/src/logger.rs
@@ -9,6 +9,7 @@ use fern_logger::{LoggerConfig, LoggerOutputConfigBuilder, logger_init};
 use log::warn;
 
 /// Initializes the logger
+#[allow(clippy::result_large_err)]
 pub fn init_logger(level: log::LevelFilter, file: &str) -> crate::Result<()> {
     let config = LoggerConfig::build()
         .with_output(LoggerOutputConfigBuilder::new().level_filter(level).name(file))

--- a/sdk/src/testing_utils.rs
+++ b/sdk/src/testing_utils.rs
@@ -50,7 +50,8 @@ pub const ENCRYPTED_SHARE: &str = "ME-RS-AesGcm-K3vx+e6IF6BOUJ2DemvsdflQq2CbolcF
 pub const NOT_ENCRYPTED_SHARE: &str = "ME-RS-N-Mi0xLUNBRVFBaGdESXFBRStPVUZYZTJnMTdLRFY1L2pWRllQTHdtZ0dCWExJbitjTERReFRyRHArWGNVMG5yY3UyVmFONFEvZkVoeXNadm5qNFhmRDVIZXZ3eHB2bENTYnZIZTFtOTlXdjJwby8zVWl0d2VhMnVWOTZaejB5WmhEdHlkRDFYcEg1R0RIYXFvZDBpTHdpcDZ3d1k5T0VWdEJhZmtkUVRGaTNNM3gvY2dsK0FDWVQ5WG50TlJycnRtWFRTUGZ4MG54R1lVc0NWUnNKY3h5Q0JxSHBlRGVRekpSTlFxVldMNGpJU3JCZkFRcEpYMnJoT1o4OXM1V3VLaW5PWFd0YUZncTRnd2t1VzR0ZkJJZzVUMjFlaXpGNEpWNzlMcXFXSDZoY3N0Z1huYzZYWTJvZjRvaytlYnJWOFBmR1lOU1NxRWQ4VFpqUzlBL0h0clJGNThEbUdaL2Z2Nmp5MjJjS01hUWllK1ZqdFZ4OUJyblJjWThYYTgxWmNTWlF4YlFLbFQ3MC9tRk5aQlN4ZXNLTWVTU24vV2hycEs0OU80ZW4zRkZJVTJqd2lLcGwybHpHMk0vdThJTzRZSlNCL1B6aVp4cGczcVk5Z25PRHNQR2lDZGNyejErcTVhYUdoMDdXUGlISFg5K1VpbVJjRThZS1BBNXUwNTBkQ2l2eVM2a2VhZkpFalQ0UXkxcElPaFRUd3ZrMWxrR0ZmeWp3bVBqL3JMRGY4YUc3ZXZlVWQveGwxbzlKMnh5ckhvQW9heTNVNVpHYjFCZGJ2OGFGNHJLb2wwTkorUlZBSTZJSHJCUnE4OGxJeGtzSlFxTm9GQ3o5b051N011OTVkMUJpZ3ErNjZiYzBuTWcyWXZYQXdaMkh3RjAzS0xRWEFWYjZVekZ1Lzc0MjYraElNUlR1M01mZDZoa01vMllMVzlxSS9odlBsaWg4RG5qaUFTUG9Fbkx2cVFidVpXaVBnQ3h2c1F4eXFBQWdDazlzckhwaG51UnpTck95M1JmZzRYa0lndHhlb3ArUmZJOVgyaDBRcEVmcjgzYzExd0xhQkxDUmgwMlFXazA2Ty8yM2s2cWZNZHBxNVZ2b0ZnTkNJYlY1V01sSFpaV3RnVXFzaGtXRVJycjduZnVvd1BQQ0NUaHdxMC9tbUQ1NDVDb0VNWU16bUtQYlIyYmF4RkVTbUswTlRRT3VWR3A2Y3JqNWlYOGxzaU9kZ3FVNHhuSVpRcDRsT1lJcTlBOUhFS3NZZ1RuYysxRlRNazJEN05ydThlalh4UUR3amFqUTFNTmJ5cldBS0MvZ3RTWW9ONTFKY25FWFlUOWI1MVZOWWF4anArTE9oeDA0M3RNUW9TejNvN1kxbWtORlJUTmJMZWhDKzV0UkNKNjdQYk5Va29DbWxXbjFYODZxVlVsRFU0MjkxaXVLaE1YQ0lsVHlscGU2dw==";
 pub const TX_INDEX: &str = "deadbeef-1234-2341-6afe";
 pub const PRODUCT_HASH: &str = "hash";
-pub const AMOUNT: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(1_000)) }; // SAFETY: we know that this value is not negative
+// SAFETY: we know that this value is not negative
+pub const AMOUNT: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(1_000)) };
 pub const REASON: &str = "COMPLIMENT";
 pub const PURCHASE_MODEL: &str = "CLIK";
 pub const RECEIVER: &str = "satoshi";
@@ -63,11 +64,14 @@ pub const PAYMENT_METHOD_ID: &str = "payment-method-id";
 pub const PAYMENT_DETAIL_ID: &str = "payment-detail-id";
 pub const CASE_ID: &str = "123";
 
-pub static ENCRYPTED_WALLET_PASSWORD: LazyLock<EncryptedPassword> = LazyLock::new(|| unsafe {
-    EncryptedPassword::new_unchecked([
-        91, 105, 102, 64, 68, 93, 59, 70, 41, 198, 141, 36, 152, 135, 67, 77, 191, 58, 227, 216, 53, 74, 74, 1, 168,
-        243, 227, 153, 73, 141, 159, 91, 79, 39, 208, 59, 54, 101, 112, 107, 169,
-    ])
+pub static ENCRYPTED_WALLET_PASSWORD: LazyLock<EncryptedPassword> = LazyLock::new(|| {
+    // SAFETY: The byte array was generated and validated at compile time
+    unsafe {
+        EncryptedPassword::new_unchecked([
+            91, 105, 102, 64, 68, 93, 59, 70, 41, 198, 141, 36, 152, 135, 67, 77, 191, 58, 227, 216, 53, 74, 74, 1,
+            168, 243, 227, 153, 73, 141, 159, 91, 79, 39, 208, 59, 54, 101, 112, 107, 169,
+        ])
+    }
 });
 pub static WALLET_PASSWORD: LazyLock<PlainPassword> =
     LazyLock::new(|| PlainPassword::try_from_string("correcthorsebatterystaple").unwrap());

--- a/sdk/src/wallet/share.rs
+++ b/sdk/src/wallet/share.rs
@@ -217,6 +217,7 @@ pub struct GeneratedShares {
 }
 
 /// Creates shares from a [`Mnemonic`] that can be resolved into a [`Mnemonic`] again when reconstructed.
+#[allow(clippy::result_large_err)]
 pub fn create_shares_from_mnemonic(
     mnemonic: impl Into<Mnemonic>,
     password: &SecretSlice<u8>,
@@ -234,6 +235,7 @@ pub fn create_shares_from_mnemonic(
 
 /// Reconstruct a [`Mnemonic`] from the shares. Can be used to initialize a wallet using the
 /// [`iota_sdk::client::secret::mnemonic::MnemonicSecretManager::try_from_mnemonic`] function.
+#[allow(clippy::result_large_err)]
 pub fn reconstruct_mnemonic(
     shares: &[&Share],
     password: Option<&SecretSlice<u8>>,
@@ -250,6 +252,7 @@ pub fn reconstruct_mnemonic(
 }
 
 /// Creates shares from any secret represented as a vector of bytes.
+#[allow(clippy::result_large_err)]
 fn create_shares_from_secret(
     payload_type: PayloadType,
     secret: &SecretSlice<u8>,
@@ -288,6 +291,7 @@ fn create_shares_from_secret(
 }
 
 /// Reconstruct the secret from provided shares.
+#[allow(clippy::result_large_err)]
 fn reconstruct_secret(
     shares: &[&Share],
     password: Option<&SecretSlice<u8>>,
@@ -345,6 +349,7 @@ fn reconstruct_secret(
     }
 }
 
+#[allow(clippy::result_large_err)]
 fn encrypt_with_password(data: &ShareData, key: &SecretSlice<u8>) -> Result<ShareData, ShareError> {
     use aes_gcm::{
         Aes256Gcm, Key,
@@ -375,6 +380,7 @@ fn encrypt_with_password(data: &ShareData, key: &SecretSlice<u8>) -> Result<Shar
     Ok(ShareData(data.into()))
 }
 
+#[allow(clippy::result_large_err)]
 fn decrypt_with_password(data: &ShareData, key: &SecretSlice<u8>) -> Result<ShareData, ShareError> {
     use aes_gcm::{
         Aes256Gcm, Key, Nonce,

--- a/sdk/src/wallet/wallet_evm.rs
+++ b/sdk/src/wallet/wallet_evm.rs
@@ -55,6 +55,7 @@ pub struct WalletImplEvm {
 
 impl WalletImplEvm {
     /// Creates a new [`WalletImplEvm`] from the specified [`Mnemonic`].
+    #[allow(clippy::result_large_err)]
     pub fn new(mnemonic: Mnemonic, node_urls: &[String], chain_id: u64, decimals: u32, coin_type: u32) -> Result<Self> {
         // Ase mnemonic to create a Signer
         let wallet = MnemonicBuilder::<English>::default()
@@ -84,11 +85,13 @@ impl WalletImplEvm {
     }
 
     /// Convert a [`U256`] to [`CryptoAmount`] while taking the decimals into account.
+    #[allow(clippy::result_large_err)]
     fn convert_alloy_256_to_crypto_amount(&self, v: alloy_primitives::Uint<256, 4>) -> Result<CryptoAmount> {
         convert_alloy_256_to_crypto_amount(v, self.decimals)
     }
 
     /// Convert a [`CryptoAmount`] to [`U256`] while taking the decimals into account.
+    #[allow(clippy::result_large_err)]
     fn convert_crypto_amount_to_u256(&self, v: CryptoAmount) -> Result<alloy_primitives::U256> {
         convert_crypto_amount_to_u256(v, self.decimals)
     }
@@ -152,6 +155,7 @@ impl WalletImplEvm {
 }
 
 /// Convert a [`U256`] to [`CryptoAmount`] while taking the decimals into account.
+#[allow(clippy::result_large_err)]
 fn convert_alloy_256_to_crypto_amount(value: U256, decimals: u32) -> Result<CryptoAmount> {
     let value_u128 = u128::try_from(value)
         .map_err(|e| WalletError::ConversionError(format!("could not convert U256 to u128: {e:?}")))?;
@@ -177,6 +181,7 @@ fn convert_alloy_256_to_crypto_amount(value: U256, decimals: u32) -> Result<Cryp
 }
 
 /// Convert a [`CryptoAmount`] to [`U256`] while taking the decimals into account.
+#[allow(clippy::result_large_err)]
 fn convert_crypto_amount_to_u256(amount: CryptoAmount, decimals: u32) -> Result<U256> {
     // normalize to remove trailing zeros
     let value_decimal = amount.inner().normalize();
@@ -324,6 +329,7 @@ pub struct WalletImplEvmErc20 {
 }
 impl WalletImplEvmErc20 {
     /// Creates a new [`WalletImplEvm`] from the specified [`Mnemonic`].
+    #[allow(clippy::result_large_err)]
     pub fn new(
         mnemonic: Mnemonic,
         node_urls: &[String],
@@ -343,6 +349,7 @@ impl WalletImplEvmErc20 {
     }
 
     /// Helper function that prepares the [`TransactionRequest`] so that we can also use the same logic for gas estimation.
+    #[allow(clippy::result_large_err)]
     fn prepare_transaction(&self, intent: &TransactionIntent) -> Result<TransactionRequest> {
         let TransactionIntent {
             address_to,

--- a/sdk/src/wallet/wallet_evm.rs
+++ b/sdk/src/wallet/wallet_evm.rs
@@ -97,6 +97,7 @@ impl WalletImplEvm {
     }
 
     /// Helper function that prepares the [`TransactionRequest`] so that we can also use the same logic for gas estimation.
+    #[allow(clippy::result_large_err)]
     fn prepare_transaction(&self, intent: &TransactionIntent) -> Result<TransactionRequest> {
         let TransactionIntent {
             address_to,

--- a/sdk/src/wallet/wallet_rebased.rs
+++ b/sdk/src/wallet/wallet_rebased.rs
@@ -62,6 +62,7 @@ impl WalletImplIotaRebased {
 }
 
 /// Convert a [`u128`] to [`CryptoAmount`] while taking the decimals into account.
+#[allow(clippy::result_large_err)]
 fn convert_u128_to_crypto_amount(value: u128, decimals: u32) -> Result<CryptoAmount> {
     let Some(mut result_decimal) = Decimal::from_u128(value) else {
         return Err(WalletError::ConversionError(format!(
@@ -83,6 +84,7 @@ fn convert_u128_to_crypto_amount(value: u128, decimals: u32) -> Result<CryptoAmo
     })
 }
 /// Convert a [`CryptoAmount`] to [`U256`] while taking the decimals into account.
+#[allow(clippy::result_large_err)]
 fn convert_crypto_amount_to_u128(amount: CryptoAmount, decimals: u32) -> Result<u128> {
     // normalize to remove trailing zeros
     let value_decimal = amount.inner().normalize();

--- a/sdk/src/wallet/wallet_stardust.rs
+++ b/sdk/src/wallet/wallet_stardust.rs
@@ -88,10 +88,12 @@ impl WalletImplStardust {
 }
 
 /// The minimum amount of IOTA to consider an output as non-dust output. Everything below this is dust.
-const MIN_DUST_OUTPUT: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(0.1)) }; // SAFETY: the value is non-negative
+// SAFETY: the value is non-negative
+const MIN_DUST_OUTPUT: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(0.1)) };
 
 /// The value to divide an amount in GLOW with to get IOTA
-const GLOW_TO_IOTA_DIVISOR: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(1_000_000)) }; // SAFETY: the value is non-negative
+// SAFETY: the value is non-negative
+const GLOW_TO_IOTA_DIVISOR: CryptoAmount = unsafe { CryptoAmount::new_unchecked(dec!(1_000_000)) };
 
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]


### PR DESCRIPTION
## Motivation and Context



## Summary

I've added annotations to suppress Clippy warnings:

- The first warning was about the potentially large size of the `Err` variant ([clippy::result\_large\_err](https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err)). We can safely ignore this for now, as the error size isn't a concern in our current context.
- The second warning was related to the placement of the `SAFETY:` comment for an `unsafe` block. I've adjusted the comment to align with Clippy's expectations.


## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
