### PR TITLE
fix: use `rand` `v0.9` whenever possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,7 +1910,6 @@ dependencies = [
  "mockall",
  "mockito",
  "rand 0.9.1",
- "rand_core 0.6.4",
  "ref-cast",
  "reqwest",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,8 +85,3 @@ syn = { version = "2.0", features = ["full"] }
 proc-macro2 = { version = "1.0", default-features = false }
 jni = { version = "0.21.1", default-features = false }
 
-# scrypt is used for the main wallet functions in the iota-sdk. Since it does a lot of 
-# cryptography hashing, running in debug mode takes forever and therefore we tell Cargo to
-# always compile it with full optimizations in debug mode.
-[profile.dev.package.scrypt]
-opt-level = 3

--- a/crates/etopay-wallet/Cargo.toml
+++ b/crates/etopay-wallet/Cargo.toml
@@ -45,8 +45,6 @@ rand = { version = "0.9", default-features = false, features = [
     "thread_rng",
 ] }
 
-rand_0_8 = { package = "rand_core", version = "0.6", default-features = false, features = [
-] }
 zeroize = { version = "1.8", default-features = false, features = ["std"] }
 
 # For EVM impl

--- a/crates/etopay-wallet/Cargo.toml
+++ b/crates/etopay-wallet/Cargo.toml
@@ -70,7 +70,7 @@ alloy-transport = "1.0.6"
 # needed for custom iota-rebased impl
 serde_with = { version = "3.12", features = ["macros", "hex"] }
 hex = { version = "0.4" }
-tiny-bip39 = "2"
+tiny-bip39 = { version = "2", default-features = false }
 slip10_ed25519 = "0.1.3"
 bcs = "0.1.6"
 serde_repr = "0.1.20"
@@ -109,6 +109,7 @@ mockall = { workspace = true }
 mockito = { workspace = true }
 rstest = { workspace = true }
 testing = { workspace = true }
+tiny-bip39 = { version = "2", default-features = false, features = ["rand"] }
 
 
 [package.metadata.cargo-machete]

--- a/crates/etopay-wallet/src/rebased/crypto/ed25519.rs
+++ b/crates/etopay-wallet/src/rebased/crypto/ed25519.rs
@@ -4,9 +4,10 @@
 
 //! Inspired by https://github.com/MystenLabs/fastcrypto/blob/main/fastcrypto/src/ed25519.rs
 
+use rand::CryptoRng;
 use std::{cell::OnceCell, fmt};
 
-use rand_0_8::{CryptoRng, RngCore};
+use rand::RngCore;
 
 use super::super::{
     RebasedError,
@@ -146,7 +147,11 @@ impl Ed25519KeyPair {
     }
 
     pub fn generate<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
-        let kp = ed25519_consensus::SigningKey::new(rng);
+        // instead of using SigningKey::new(rng), we manually get the bytes using the working version of the `rand` crate
+        let mut bytes = [0u8; 32];
+        rng.fill_bytes(&mut bytes[..]);
+        let kp = ed25519_consensus::SigningKey::from(bytes);
+
         Ed25519KeyPair {
             public: Ed25519PublicKey(kp.verification_key()),
             private: Ed25519PrivateKey(kp),

--- a/sdk/src/wallet/share.rs
+++ b/sdk/src/wallet/share.rs
@@ -342,13 +342,16 @@ fn reconstruct_secret(
 #[allow(clippy::result_large_err)]
 fn encrypt_with_password(data: &ShareData, key: &SecretSlice<u8>) -> Result<ShareData, ShareError> {
     use aes_gcm::{
-        Aes256Gcm, Key,
-        aead::{Aead, AeadCore, KeyInit, OsRng},
+        Aes256Gcm, Key, Nonce,
+        aead::{Aead, KeyInit, consts::U12},
     };
+    use rand::RngCore;
 
     // create a random nonce value (96-bit for AesGcm256) since it needs to be unique for each
     // encryption with the same key
-    let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
+    let mut nonce = Nonce::<U12>::default();
+    let mut rng = rand::rng();
+    rng.fill_bytes(&mut nonce);
 
     // hash the key string with the nonce to use as encryption key
     let key = Blake2b256::new()

--- a/sdk/src/wallet/wallet_manager.rs
+++ b/sdk/src/wallet/wallet_manager.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use etopay_wallet::bip39::{self, Mnemonic};
 use etopay_wallet::{WalletImplEvm, WalletImplEvmErc20, WalletImplIotaRebased, WalletUser};
 use log::{info, warn};
+use rand::RngCore;
 use secrecy::SecretBox;
 use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
@@ -387,7 +388,14 @@ impl WalletManager for WalletManagerImpl {
         repo: &mut UserRepoT,
         pin: &EncryptionPin,
     ) -> Result<String> {
-        let mnemonic = Mnemonic::new(bip39::MnemonicType::Words24, bip39::Language::English);
+        let bytes = {
+            let mut rng = rand::rng();
+            let mut bytes = vec![0u8; 32];
+            rng.fill_bytes(&mut bytes);
+            bytes
+        };
+
+        let mnemonic = Mnemonic::from_entropy(&bytes, bip39::Language::English)?;
         self.create_and_upload_shares(config, access_token, repo, pin, &mnemonic)
             .await?;
 


### PR DESCRIPTION
## Motivation and Context

This makes the core functionality (except for storing kdbx files) work under `node` 💯 

## Summary

Provide a short summary of changes in this pull request.

- In places where possible, directly inject the random bytes (eg. entropy) instead of letting each library use their own (old) version of the `rand` crate which does not play nice with `node` at the moment.
- Remove the need to directly depend on the old version of `rand` 💯 

Note: not all use of the old version is fixed. The backup generation using the `kdbx` crate will continue to not work under `node`.

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [x] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
