### PR TITLE
feat: add support for specifying wallet derivation account and index values

### DIFF
--- a/bindings/wasm/examples/06-generate_new_address.ts
+++ b/bindings/wasm/examples/06-generate_new_address.ts
@@ -20,7 +20,13 @@ async function main() {
     await sdk.createNewWallet(PIN);
     console.log("Wallet initialized!");
     let address = await sdk.generateNewAddress(PIN);
-    console.log("Address:", address);
+    console.log("First Address:", address);
+
+    // update the account and index to get another address
+    await sdk.setWalletAccount(0, 1);
+    let address2 = await sdk.generateNewAddress(PIN);
+    console.log("Second Address:", address2);
+
 }
 
 main();

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -552,8 +552,8 @@ impl ETOPaySdk {
     /// Set the account and index used for deriving the private key from the mnemonic. This is used
     /// to have multiple accounts and addresses with a single mnemonic.
     ///
-    /// @param {number} start - The start page
-    /// @param {number} limit - The limit per page
+    /// @param {number} account - The account number
+    /// @param {number} index - The index number
     ///
     /// @returns {Promise<TxList>} The details of the created purchases
     #[wasm_bindgen(skip_jsdoc, js_name = "setWalletAccount")]

--- a/bindings/wasm/src/lib.rs
+++ b/bindings/wasm/src/lib.rs
@@ -549,6 +549,21 @@ impl ETOPaySdk {
             .map_err(|e| format!("{e:#?}"))
     }
 
+    /// Set the account and index used for deriving the private key from the mnemonic. This is used
+    /// to have multiple accounts and addresses with a single mnemonic.
+    ///
+    /// @param {number} start - The start page
+    /// @param {number} limit - The limit per page
+    ///
+    /// @returns {Promise<TxList>} The details of the created purchases
+    #[wasm_bindgen(skip_jsdoc, js_name = "setWalletAccount")]
+    pub async fn set_wallet_account(&self, account: u32, index: u32) -> Result<(), String> {
+        let mut sdk = self.inner.write().await;
+        sdk.set_wallet_derivation_options(account, index)
+            .await
+            .map_err(|e| format!("{e:#?}"))
+    }
+
     /// Gets the current exchange rate for the cryptocurrency to EURO
     ///
     /// @returns {Promise<number>} The exchange rate as a floating point number

--- a/crates/etopay-wallet/src/wallet.rs
+++ b/crates/etopay-wallet/src/wallet.rs
@@ -15,6 +15,13 @@ pub struct TransactionIntent {
     pub data: Option<Vec<u8>>,
 }
 
+/// Options that can be given to customize the mnemonic derivation
+#[derive(Debug, Default)]
+pub struct MnemonicDerivationOption {
+    pub account: u32,
+    pub index: u32,
+}
+
 #[cfg_attr(any(test, feature = "mock"), mockall::automock)]
 #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
 #[cfg_attr(not(target_arch = "wasm32"), async_trait)]

--- a/crates/etopay-wallet/src/wallet_evm.rs
+++ b/crates/etopay-wallet/src/wallet_evm.rs
@@ -1,5 +1,6 @@
 use super::error::Result;
 use super::wallet::{TransactionIntent, WalletUser};
+use crate::MnemonicDerivationOption;
 use crate::error::WalletError;
 use crate::types::{CryptoAmount, GasCostEstimation, WalletTxInfo, WalletTxInfoList, WalletTxStatus};
 use alloy::eips::BlockNumberOrTag;
@@ -55,12 +56,19 @@ pub struct WalletImplEvm {
 impl WalletImplEvm {
     /// Creates a new [`WalletImplEvm`] from the specified [`Mnemonic`].
     #[allow(clippy::result_large_err)]
-    pub fn new(mnemonic: Mnemonic, node_urls: &[String], chain_id: u64, decimals: u32, coin_type: u32) -> Result<Self> {
+    pub fn new(
+        mnemonic: Mnemonic,
+        node_urls: &[String],
+        chain_id: u64,
+        decimals: u32,
+        coin_type: u32,
+        options: MnemonicDerivationOption,
+    ) -> Result<Self> {
         // Ase mnemonic to create a Signer
         let wallet = MnemonicBuilder::<English>::default()
             .phrase(mnemonic.as_ref().to_string())
             // Child key at derivation path: m/44'/{coin_type}'/{account}'/{change}/{index}.
-            .derivation_path(format!("m/44'/{}'/0'/0/0", coin_type))?
+            .derivation_path(format!("m/44'/{}'/{}'/0/{}", coin_type, options.account, options.index))?
             // // Use this if your mnemonic is encrypted.
             // .password(password)
             .build()?;
@@ -356,9 +364,10 @@ impl WalletImplEvmErc20 {
         decimals: u32,
         coin_type: u32,
         contract_address: &str,
+        options: MnemonicDerivationOption,
     ) -> Result<Self> {
         Ok(Self {
-            inner: WalletImplEvm::new(mnemonic, node_urls, chain_id, decimals, coin_type)?,
+            inner: WalletImplEvm::new(mnemonic, node_urls, chain_id, decimals, coin_type, options)?,
             contract_address: contract_address.parse()?,
         })
     }
@@ -524,8 +533,15 @@ mod tests {
         let chain_id = 31337;
 
         let mnemonic = Mnemonic::from_phrase(mnemonic_phrase.as_ref(), Language::English).expect("invalid mnemonic");
-        let wallet = WalletImplEvm::new(mnemonic, &node_url, chain_id, ETH_DECIMALS, ETH_COIN_TYPE)
-            .expect("should initialize wallet");
+        let wallet = WalletImplEvm::new(
+            mnemonic,
+            &node_url,
+            chain_id,
+            ETH_DECIMALS,
+            ETH_COIN_TYPE,
+            MnemonicDerivationOption::default(),
+        )
+        .expect("should initialize wallet");
         (wallet, cleanup)
     }
 
@@ -536,8 +552,15 @@ mod tests {
         chain_id: u64,
     ) -> WalletImplEvm {
         let mnemonic = Mnemonic::from_phrase(mnemonic_phrase.as_ref(), Language::English).expect("invalid mnemonic");
-        WalletImplEvm::new(mnemonic, &[node_url], chain_id, ETH_DECIMALS, ETH_COIN_TYPE)
-            .expect("could not initialize WalletImplEth")
+        WalletImplEvm::new(
+            mnemonic,
+            &[node_url],
+            chain_id,
+            ETH_DECIMALS,
+            ETH_COIN_TYPE,
+            MnemonicDerivationOption::default(),
+        )
+        .expect("could not initialize WalletImplEth")
     }
 
     #[tokio::test]

--- a/crates/etopay-wallet/src/wallet_evm.rs
+++ b/crates/etopay-wallet/src/wallet_evm.rs
@@ -62,7 +62,7 @@ impl WalletImplEvm {
         chain_id: u64,
         decimals: u32,
         coin_type: u32,
-        options: MnemonicDerivationOption,
+        options: &MnemonicDerivationOption,
     ) -> Result<Self> {
         // Ase mnemonic to create a Signer
         let wallet = MnemonicBuilder::<English>::default()
@@ -364,7 +364,7 @@ impl WalletImplEvmErc20 {
         decimals: u32,
         coin_type: u32,
         contract_address: &str,
-        options: MnemonicDerivationOption,
+        options: &MnemonicDerivationOption,
     ) -> Result<Self> {
         Ok(Self {
             inner: WalletImplEvm::new(mnemonic, node_urls, chain_id, decimals, coin_type, options)?,
@@ -539,7 +539,7 @@ mod tests {
             chain_id,
             ETH_DECIMALS,
             ETH_COIN_TYPE,
-            MnemonicDerivationOption::default(),
+            &MnemonicDerivationOption::default(),
         )
         .expect("should initialize wallet");
         (wallet, cleanup)
@@ -558,7 +558,7 @@ mod tests {
             chain_id,
             ETH_DECIMALS,
             ETH_COIN_TYPE,
-            MnemonicDerivationOption::default(),
+            &MnemonicDerivationOption::default(),
         )
         .expect("could not initialize WalletImplEth")
     }

--- a/crates/etopay-wallet/src/wallet_rebased.rs
+++ b/crates/etopay-wallet/src/wallet_rebased.rs
@@ -7,6 +7,7 @@ use super::rebased::{
     RebasedError, RpcClient, TransactionData, TransactionExpiration,
 };
 use super::wallet::{TransactionIntent, WalletUser};
+use crate::MnemonicDerivationOption;
 use crate::rebased::{
     CheckpointId, GovernanceReadApiClient, IotaTransactionBlockEffects, Owner, ReadApiClient, TransactionKind,
     WriteApiClient,
@@ -42,9 +43,18 @@ impl std::fmt::Debug for WalletImplIotaRebased {
 
 impl WalletImplIotaRebased {
     /// Creates a new [`WalletImpl`] from the specified [`Config`] and [`Mnemonic`].
-    pub async fn new(mnemonic: Mnemonic, coin_type: &str, decimals: u32, node_url: &[String]) -> Result<Self> {
+    pub async fn new(
+        mnemonic: Mnemonic,
+        coin_type: &str,
+        decimals: u32,
+        node_url: &[String],
+        options: MnemonicDerivationOption,
+    ) -> Result<Self> {
         let mut keystore2 = rebased::InMemKeystore::default();
-        keystore2.import_from_mnemonic(mnemonic, "m/44'/4218'/0'/0'/0'".parse::<bip32::DerivationPath>()?)?;
+        keystore2.import_from_mnemonic(
+            mnemonic,
+            format!("m/44'/4218'/{}'/0'/{}'", options.account, options.index).parse::<bip32::DerivationPath>()?,
+        )?;
 
         let client = RpcClient::new(&node_url[0]).await?;
 

--- a/crates/etopay-wallet/src/wallet_rebased.rs
+++ b/crates/etopay-wallet/src/wallet_rebased.rs
@@ -48,7 +48,7 @@ impl WalletImplIotaRebased {
         coin_type: &str,
         decimals: u32,
         node_url: &[String],
-        options: MnemonicDerivationOption,
+        options: &MnemonicDerivationOption,
     ) -> Result<Self> {
         let mut keystore2 = rebased::InMemKeystore::default();
         keystore2.import_from_mnemonic(

--- a/sdk/src/core/core_testing_utils.rs
+++ b/sdk/src/core/core_testing_utils.rs
@@ -37,6 +37,7 @@ pub async fn handle_error_test_cases(
             sdk.active_user = Some(crate::types::users::ActiveUser {
                 username: USERNAME.into(),
                 wallet_manager: Box::new(MockWalletManager::new()),
+                mnemonic_derivation_options: Default::default(),
             });
             sdk.access_token = Some(TOKEN.clone());
             sdk.config = None;
@@ -52,6 +53,7 @@ pub async fn handle_error_test_cases(
             sdk.active_user = Some(crate::types::users::ActiveUser {
                 username: USERNAME.into(),
                 wallet_manager: Box::new(MockWalletManager::new()),
+                mnemonic_derivation_options: Default::default(),
             });
             sdk.set_networks(example_api_networks());
             sdk.active_network = None;
@@ -69,6 +71,7 @@ pub async fn handle_error_test_cases(
             sdk.active_user = Some(crate::types::users::ActiveUser {
                 username: USERNAME.into(),
                 wallet_manager: Box::new(MockWalletManager::new()),
+                mnemonic_derivation_options: Default::default(),
             });
 
             sdk.access_token = None;
@@ -93,6 +96,7 @@ pub async fn handle_error_test_cases(
             sdk.active_user = Some(crate::types::users::ActiveUser {
                 username: USERNAME.into(),
                 wallet_manager: Box::new(MockWalletManager::new()),
+                mnemonic_derivation_options: Default::default(),
             });
         }
         crate::Error::UserRepository(crate::user::error::UserKvStorageError::UserNotFound { .. }) => {
@@ -107,6 +111,7 @@ pub async fn handle_error_test_cases(
             sdk.active_user = Some(crate::types::users::ActiveUser {
                 username: USERNAME.into(),
                 wallet_manager: Box::new(MockWalletManager::new()),
+                mnemonic_derivation_options: Default::default(),
             });
         }
         other => panic!("Got unexpected or unhandled result: {:?}", other),

--- a/sdk/src/core/exchange.rs
+++ b/sdk/src/core/exchange.rs
@@ -64,6 +64,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
                 sdk.set_networks(example_api_networks());
@@ -146,6 +147,7 @@ mod tests {
         ActiveUser {
             username: USERNAME.into(),
             wallet_manager: Box::new(MockWalletManager::new()),
+            mnemonic_derivation_options: Default::default(),
         }
     }
 }

--- a/sdk/src/core/mod.rs
+++ b/sdk/src/core/mod.rs
@@ -210,6 +210,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.set_networks(example_api_networks());
                 sdk.set_network(IOTA_NETWORK_KEY.to_string()).await.unwrap();
@@ -256,6 +257,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 

--- a/sdk/src/core/mod.rs
+++ b/sdk/src/core/mod.rs
@@ -154,7 +154,14 @@ impl Sdk {
         let config = self.config.as_mut().ok_or(crate::Error::MissingConfig)?;
         let wallet = active_user
             .wallet_manager
-            .try_get(config, &self.access_token, repo, network, pin)
+            .try_get(
+                config,
+                &self.access_token,
+                repo,
+                network,
+                pin,
+                &active_user.mnemonic_derivation_options,
+            )
             .await?;
         Ok(wallet)
     }

--- a/sdk/src/core/postident.rs
+++ b/sdk/src/core/postident.rs
@@ -145,6 +145,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 
@@ -176,6 +177,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = None;
             }
@@ -193,6 +195,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
                 sdk.config = None;
@@ -203,6 +206,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -245,6 +249,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 
@@ -302,6 +307,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 

--- a/sdk/src/core/share.rs
+++ b/sdk/src/core/share.rs
@@ -79,6 +79,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -120,6 +121,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {

--- a/sdk/src/core/transaction.rs
+++ b/sdk/src/core/transaction.rs
@@ -165,7 +165,14 @@ impl Sdk {
 
         let wallet = active_user
             .wallet_manager
-            .try_get(config, &self.access_token, repo, network, pin)
+            .try_get(
+                config,
+                &self.access_token,
+                repo,
+                network,
+                pin,
+                &active_user.mnemonic_derivation_options,
+            )
             .await?;
 
         let amount = tx_details.amount.try_into()?;
@@ -244,7 +251,14 @@ impl Sdk {
 
         let wallet = active_user
             .wallet_manager
-            .try_get(config, &self.access_token, repo, network, pin)
+            .try_get(
+                config,
+                &self.access_token,
+                repo,
+                network,
+                pin,
+                &active_user.mnemonic_derivation_options,
+            )
             .await?;
 
         // create the transaction payload which holds a tag and associated data
@@ -315,7 +329,14 @@ impl Sdk {
 
         let wallet = active_user
             .wallet_manager
-            .try_get(config, &self.access_token, repo, network, pin)
+            .try_get(
+                config,
+                &self.access_token,
+                repo,
+                network,
+                pin,
+                &active_user.mnemonic_derivation_options,
+            )
             .await?;
 
         // create the transaction payload which holds a tag and associated data
@@ -532,7 +553,7 @@ mod tests {
                 sdk.repo = Some(Box::new(mock_user_repo));
 
                 let mut mock_wallet_manager = MockWalletManager::new();
-                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
                     let mut mock_wallet_user = MockWalletUser::new();
                     mock_wallet_user
                         .expect_send_amount()
@@ -719,7 +740,7 @@ mod tests {
                 sdk.repo = Some(Box::new(mock_user_repo));
 
                 let mut mock_wallet_manager = MockWalletManager::new();
-                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
                     let mut mock_wallet = MockWalletUser::new();
                     mock_wallet
                         .expect_send_amount()
@@ -799,7 +820,7 @@ mod tests {
         sdk.repo = Some(Box::new(mock_user_repo));
 
         let mut mock_wallet_manager = MockWalletManager::new();
-        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
             let mut mock_wallet = MockWalletUser::new();
             mock_wallet
                 .expect_send_amount()

--- a/sdk/src/core/transaction.rs
+++ b/sdk/src/core/transaction.rs
@@ -463,6 +463,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 
@@ -543,6 +544,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
 
                 sdk.access_token = Some(TOKEN.clone());
@@ -583,6 +585,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
 
                 sdk.access_token = Some(TOKEN.clone());
@@ -645,6 +648,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 
@@ -731,6 +735,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -813,6 +818,7 @@ mod tests {
         sdk.active_user = Some(crate::types::users::ActiveUser {
             username: USERNAME.into(),
             wallet_manager: Box::new(mock_wallet_manager),
+            mnemonic_derivation_options: Default::default(),
         });
 
         // Act
@@ -851,6 +857,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 

--- a/sdk/src/core/user.rs
+++ b/sdk/src/core/user.rs
@@ -278,6 +278,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -318,6 +319,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -363,6 +365,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_user),
+                    mnemonic_derivation_options: Default::default(),
                 });
 
                 sdk.access_token = Some(TOKEN.clone());
@@ -427,6 +430,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
 
                 sdk.access_token = Some(TOKEN.clone());
@@ -487,6 +491,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
 
                 sdk.access_token = Some(TOKEN.clone());
@@ -543,6 +548,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 
@@ -592,6 +598,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
 

--- a/sdk/src/core/viviswap/swap.rs
+++ b/sdk/src/core/viviswap/swap.rs
@@ -792,7 +792,7 @@ mod tests {
 
         let mut mock_wallet_manager = MockWalletManager::new();
         mock_wallet_manager.expect_try_get().returning({
-            move |_, _, _, _, _| {
+            move |_, _, _, _, _, _| {
                 let mut mock_wallet = MockWalletUser::new();
                 mock_wallet
                     .expect_get_address()

--- a/sdk/src/core/viviswap/swap.rs
+++ b/sdk/src/core/viviswap/swap.rs
@@ -592,6 +592,7 @@ mod tests {
         ActiveUser {
             username: USERNAME.into(),
             wallet_manager: Box::new(MockWalletManager::new()),
+            mnemonic_derivation_options: Default::default(),
         }
     }
 
@@ -803,6 +804,7 @@ mod tests {
         sdk.active_user = Some(ActiveUser {
             username: USERNAME.into(),
             wallet_manager: Box::new(mock_wallet_manager),
+            mnemonic_derivation_options: Default::default(),
         });
 
         // create viviswap contract

--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -434,7 +434,14 @@ impl Sdk {
         let config = self.config.as_mut().ok_or(crate::Error::MissingConfig)?;
         let wallet = active_user
             .wallet_manager
-            .try_get(config, &self.access_token, repo, network, pin)
+            .try_get(
+                config,
+                &self.access_token,
+                repo,
+                network,
+                pin,
+                &active_user.mnemonic_derivation_options,
+            )
             .await?;
 
         let address = wallet.get_address().await?;
@@ -1060,7 +1067,7 @@ mod tests {
                 sdk.repo = Some(Box::new(mock_user_repo));
 
                 let mut mock_wallet_manager = MockWalletManager::new();
-                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
                     let mut mock_wallet_user = MockWalletUser::new();
                     mock_wallet_user
                         .expect_get_address()
@@ -1135,7 +1142,7 @@ mod tests {
                 sdk.repo = Some(Box::new(mock_user_repo));
 
                 let mut mock_wallet_manager = MockWalletManager::new();
-                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
                     let mut mock_wallet_user = MockWalletUser::new();
                     mock_wallet_user
                         .expect_get_balance()
@@ -1188,7 +1195,7 @@ mod tests {
                 sdk.repo = Some(Box::new(mock_user_repo));
 
                 let mut mock_wallet_manager = MockWalletManager::new();
-                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
                     let mut mock_wallet_user = MockWalletUser::new();
                     mock_wallet_user
                         .expect_get_wallet_tx()
@@ -1244,7 +1251,7 @@ mod tests {
                 sdk.repo = Some(Box::new(mock_user_repo));
 
                 let mut mock_wallet_manager = MockWalletManager::new();
-                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+                mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
                     let mock_wallet_user = MockWalletUser::new();
                     Ok(WalletBorrow::from(mock_wallet_user))
                 });
@@ -1404,7 +1411,7 @@ mod tests {
         sdk.repo = Some(Box::new(mock_user_repo));
 
         let mut mock_wallet_manager = MockWalletManager::new();
-        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
             let mut mock_wallet_user = MockWalletUser::new();
             mock_wallet_user
                 .expect_get_wallet_tx()
@@ -1504,7 +1511,7 @@ mod tests {
         sdk.repo = Some(Box::new(mock_user_repo));
 
         let mut mock_wallet_manager = MockWalletManager::new();
-        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+        mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
             let mut mock_wallet_user = MockWalletUser::new();
             mock_wallet_user.expect_get_wallet_tx().never();
             Ok(WalletBorrow::from(mock_wallet_user))

--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -10,7 +10,11 @@ use crate::{
     types::newtypes::{EncryptionPin, EncryptionSalt, PlainPassword},
     wallet::error::{ErrorKind, WalletError},
 };
-use etopay_wallet::types::{CryptoAmount, WalletTxInfo, WalletTxInfoList, WalletTxStatus};
+use etopay_wallet::{
+    MnemonicDerivationOption,
+    types::{CryptoAmount, WalletTxInfo, WalletTxInfoList, WalletTxStatus},
+};
+
 use log::{debug, info, warn};
 
 impl Sdk {
@@ -581,6 +585,30 @@ impl Sdk {
         let wallet_tx = wallet.get_wallet_tx(tx_id).await?;
         Ok(wallet_tx)
     }
+
+    /// Set wallet mnemonic derivation options
+    ///
+    /// # Arguments
+    ///
+    /// * `account` - The account to use.
+    /// * `index` - The index to use.
+    ///
+    /// # Errors
+    ///
+    /// * [`crate::Error::UserNotInitialized`] - If there is an error initializing the user.
+    pub async fn set_wallet_derivation_options(&mut self, account: u32, index: u32) -> Result<()> {
+        let options = MnemonicDerivationOption { account, index };
+
+        info!("Setting wallet mnemonic derivation options: {options:?}");
+
+        let Some(active_user) = &mut self.active_user else {
+            return Err(crate::Error::UserNotInitialized);
+        };
+
+        active_user.mnemonic_derivation_options = options;
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -632,6 +660,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -675,6 +704,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -716,6 +746,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -759,6 +790,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -800,6 +832,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -849,6 +882,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
 
                 let new_pin = EncryptionPin::try_from_string("123456").unwrap();
@@ -892,6 +926,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -933,6 +968,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -986,6 +1022,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(MockWalletManager::new()),
+                    mnemonic_derivation_options: Default::default(),
                 });
             }
             Err(error) => {
@@ -1034,6 +1071,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.access_token = Some(TOKEN.clone());
                 sdk.set_networks(example_api_networks());
@@ -1109,6 +1147,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.set_networks(example_api_networks());
                 sdk.set_network(IOTA_NETWORK_KEY.to_string()).await.unwrap();
@@ -1160,6 +1199,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.set_networks(example_api_networks());
                 sdk.set_network(IOTA_NETWORK_KEY.to_string()).await.unwrap();
@@ -1211,6 +1251,7 @@ mod tests {
                 sdk.active_user = Some(crate::types::users::ActiveUser {
                     username: USERNAME.into(),
                     wallet_manager: Box::new(mock_wallet_manager),
+                    mnemonic_derivation_options: Default::default(),
                 });
                 sdk.set_networks(example_api_networks());
                 sdk.set_network(IOTA_NETWORK_KEY.to_string()).await.unwrap();
@@ -1388,6 +1429,7 @@ mod tests {
         sdk.active_user = Some(crate::types::users::ActiveUser {
             username: USERNAME.into(),
             wallet_manager: Box::new(mock_wallet_manager),
+            mnemonic_derivation_options: Default::default(),
         });
 
         sdk.set_networks(example_api_networks());
@@ -1471,6 +1513,7 @@ mod tests {
         sdk.active_user = Some(crate::types::users::ActiveUser {
             username: USERNAME.into(),
             wallet_manager: Box::new(mock_wallet_manager),
+            mnemonic_derivation_options: Default::default(),
         });
 
         sdk.set_networks(example_api_networks());

--- a/sdk/src/testing_utils.rs
+++ b/sdk/src/testing_utils.rs
@@ -345,7 +345,7 @@ pub fn example_crypto_details() -> Option<ViviswapApiContractDetails> {
 
 pub fn example_wallet_borrow() -> MockWalletManager {
     let mut mock_wallet_manager = MockWalletManager::new();
-    mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _| {
+    mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
         let mock_wallet_user = MockWalletUser::new();
         Ok(WalletBorrow::from(mock_wallet_user))
     });

--- a/sdk/src/types/users.rs
+++ b/sdk/src/types/users.rs
@@ -3,7 +3,7 @@ use crate::{
     types::viviswap::ViviswapState,
     wallet_manager::{WalletManager, WalletManagerImpl},
 };
-use etopay_wallet::types::WalletTxInfo;
+use etopay_wallet::{MnemonicDerivationOption, types::WalletTxInfo};
 use serde::{Deserialize, Serialize};
 
 /// Struct for storing a user in the database
@@ -40,6 +40,9 @@ pub struct ActiveUser {
 
     /// The user's wallet manager that can create a WalletUser instance from shares.
     pub wallet_manager: Box<dyn WalletManager + Send + Sync + 'static>,
+
+    /// The currently active [`MnemonicDerivationOption`]
+    pub mnemonic_derivation_options: MnemonicDerivationOption,
 }
 
 impl From<UserEntity> for ActiveUser {
@@ -47,6 +50,7 @@ impl From<UserEntity> for ActiveUser {
         ActiveUser {
             wallet_manager: Box::new(WalletManagerImpl::new(&entity.username)),
             username: entity.username,
+            mnemonic_derivation_options: Default::default(),
         }
     }
 }

--- a/sdk/src/wallet/wallet_manager.rs
+++ b/sdk/src/wallet/wallet_manager.rs
@@ -138,6 +138,7 @@ pub trait WalletManager: std::fmt::Debug {
         repo: &mut UserRepoT,
         network: &ApiNetwork,
         pin: &EncryptionPin,
+        options: &MnemonicDerivationOption,
     ) -> Result<WalletBorrow<'a>>;
 }
 
@@ -536,11 +537,9 @@ impl WalletManager for WalletManagerImpl {
         repo: &mut UserRepoT,
         network: &ApiNetwork,
         pin: &EncryptionPin,
+        options: &MnemonicDerivationOption,
     ) -> Result<WalletBorrow<'a>> {
         let (mnemonic, _status) = self.try_resemble_shares(config, access_token, repo, pin).await?;
-
-        // TODO: allow the user to specify this (somehow..)
-        let options = MnemonicDerivationOption::default();
 
         // we have the mnemonic and can now instantiate the WalletImpl
         let bo = match &network.protocol {
@@ -724,6 +723,7 @@ mod tests {
                 &mut repo,
                 &example_api_network(IOTA_NETWORK_KEY.to_string()),
                 pin,
+                &Default::default(),
             )
             .await
             .expect("should succeed to get wallet after password change");
@@ -754,6 +754,7 @@ mod tests {
                 &mut repo,
                 &example_api_network(IOTA_NETWORK_KEY.to_string()),
                 pin,
+                &Default::default(),
             )
             .await
             .expect("should succeed to get wallet");
@@ -978,6 +979,7 @@ mod tests {
                     &mut repo,
                     &example_api_network(IOTA_NETWORK_KEY.to_string()),
                     &pin,
+                    &Default::default(),
                 )
                 .await
                 .unwrap();


### PR DESCRIPTION
## Motivation and Context

We need to support having multiple accounts and addresses with the same mnemonic :rocket:

## Summary

Provide a short summary of changes in this pull request.

- Introduce `MnemonicDerivationOption` struct with the `account` and `index` numbers.
- Use the `account` and `index` numbers in the key derivation for both EVM and IOTA Rebased.
- Update tests.
- Add binding for WASM (`setWalletAccount(account,index)`) and add example usage in `generate_new_address` 🔥 

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [x] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
