### PR TITLE
fix(swift):create a new argument vector to avoid double-free issue in example

### DIFF
--- a/bindings/swift/examples/Sources/13_send_amount/main.swift
+++ b/bindings/swift/examples/Sources/13_send_amount/main.swift
@@ -54,8 +54,15 @@ Task {
         let estimate = try await sdk.estimateGas(env.pin, address.toString(), 1, rustVec)
         print("estimate: \(estimate.gas_limit.toString())")
 
+        // Note: cannot reuse the RustVec since Rust takes ownership and deallocates it when its done.
+        // thus we need to create a new one to use for the next call.
+        let rustVec2 = RustVec<UInt8>.init()
+        for byte in message.utf8 {
+            rustVec2.push(value: byte)
+        }
+
         // Send amount
-        let tx_id = try await sdk.sendAmount(env.pin, address.toString(), 1, rustVec)
+        let tx_id = try await sdk.sendAmount(env.pin, address.toString(), 1, rustVec2)
         print("sent amount of 1 on transaction \(tx_id.toString())")
 
         // Get new balance


### PR DESCRIPTION
## Motivation and Context

It turns out that reusing `RustVec`s causes issues since Rust takes ownership and deallocates it, which the swift code does not know about. Thus we need to duplicate the `data` `RustVec` before calling `sendAmount` 💯 

We should probably see if we can take a `&[u8]` or something instead of `Vec<u8>`, or document more clear that this is the case. This is a hotfix for now though!


## Checklist

Please ensure that your PR meets the following requirements:

### General

- [x] Code follows project style and guidelines.
- [x] No redundant or duplicate code.
- [x] No added new dependencies without clear justification and approval.

### Documentation

- [x] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [x] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [x] Tests pass locally.

### Build & CI/CD

- [x] Confirmed no CI/CD pipeline issues.
- [x] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
