### PR TITLE
feat: fetch transaction list from IOTA Rebased node

### DIFF
--- a/crates/etopay-wallet/src/lib.rs
+++ b/crates/etopay-wallet/src/lib.rs
@@ -3,6 +3,7 @@ mod rebased;
 mod wallet;
 mod wallet_evm;
 mod wallet_rebased;
+mod wallet_tx_sort;
 
 pub mod types;
 
@@ -10,6 +11,7 @@ pub use error::{Result, WalletError};
 pub use wallet::*;
 pub use wallet_evm::{WalletImplEvm, WalletImplEvmErc20};
 pub use wallet_rebased::WalletImplIotaRebased;
+pub use wallet_tx_sort::*;
 
 /// Re-export the bip39 crate so that our users can create [`bip39::Mnemonic`]s
 pub use bip39;

--- a/crates/etopay-wallet/src/rebased/rpc/indexer.rs
+++ b/crates/etopay-wallet/src/rebased/rpc/indexer.rs
@@ -1,0 +1,117 @@
+// Copyright (c) Mysten Labs, Inc.
+// Modifications Copyright (c) 2024 IOTA Stiftung
+// Modifications Copyright (c) 2025 ETO GRUPPE TECHNOLOGIES GmbH
+// SPDX-License-Identifier: Apache-2.0
+
+// From https://github.com/iotaledger/iota/blob/develop/crates/iota-json-rpc-api/src/indexer.rs
+
+use serde_json::json;
+
+use crate::rebased::{
+    RpcClient,
+    client::{RawRpcResponse, RpcResult},
+};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+
+use super::{
+    super::{IotaAddress, TransactionDigest},
+    IotaTransactionBlockResponse, IotaTransactionBlockResponseOptions,
+};
+
+/// Provides methods to query transactions, events, or objects and allows to
+/// subscribe to data streams.
+pub trait IndexerApi {
+    /// Return list of transactions for a specified query criteria.
+    #[rustfmt::skip]
+    // #[method(name = "queryTransactionBlocks")]
+    async fn query_transaction_blocks(
+        &self,
+        // the transaction query criteria.
+        query: IotaTransactionBlockResponseQuery,
+        // An optional paging cursor. If provided, the query will start from the next item after the specified cursor. Default to start from the first item if not specified.
+        cursor: Option<TransactionDigest>,
+        // Maximum item returned per page, default to QUERY_MAX_RESULT_LIMIT if not specified.
+        limit: Option<usize>,
+        // query result ordering, default to false (ascending order), oldest record first.
+        descending_order: Option<bool>,
+    ) -> RpcResult<TransactionBlocksPage>;
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase", rename = "TransactionBlockResponseQuery", default)]
+pub struct IotaTransactionBlockResponseQuery {
+    /// If None, no filter will be applied
+    pub filter: Option<TransactionFilter>,
+    /// config which fields to include in the response, by default only digest
+    /// is included
+    pub options: Option<IotaTransactionBlockResponseOptions>,
+}
+
+#[serde_as]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum TransactionFilter {
+    // /// Query by checkpoint.
+    // Checkpoint(
+    //     #[schemars(with = "BigInt<u64>")]
+    //     #[serde_as(as = "Readable<BigInt<u64>, _>")]
+    //     CheckpointSequenceNumber,
+    // ),
+    // /// Query by move function.
+    // MoveFunction {
+    //     package: ObjectID,
+    //     module: Option<String>,
+    //     function: Option<String>,
+    // },
+    // /// Query by input object.
+    // InputObject(ObjectID),
+    // /// Query by changed object, including created, mutated and unwrapped
+    // /// objects.
+    // ChangedObject(ObjectID),
+    /// Query by sender address.
+    FromAddress(IotaAddress),
+    /// Query by recipient address.
+    ToAddress(IotaAddress),
+    // /// Query by sender and recipient address.
+    // FromAndToAddress { from: IotaAddress, to: IotaAddress },
+    // /// Query txs that have a given address as sender or recipient.
+    // /// Note: only supported by the indexer! (different URL)
+    // FromOrToAddress { addr: IotaAddress },
+    // /// Query by transaction kind
+    // TransactionKind(IotaTransactionKind),
+    // /// Query transactions of any given kind in the input.
+    // TransactionKindIn(Vec<IotaTransactionKind>),
+}
+
+pub type TransactionBlocksPage = super::Page<IotaTransactionBlockResponse, TransactionDigest>;
+
+impl IndexerApi for RpcClient {
+    async fn query_transaction_blocks(
+        &self,
+        // the transaction query criteria.
+        query: IotaTransactionBlockResponseQuery,
+        // An optional paging cursor. If provided, the query will start from the next item after the specified cursor. Default to start from the first item if not specified.
+        cursor: Option<TransactionDigest>,
+        // Maximum item returned per page, default to QUERY_MAX_RESULT_LIMIT if not specified.
+        limit: Option<usize>,
+        // query result ordering, default to false (ascending order), oldest record first.
+        descending_order: Option<bool>,
+    ) -> RpcResult<TransactionBlocksPage> {
+        let request_body = json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "iotax_queryTransactionBlocks",
+            "params": [
+                json!(query),
+                json!(cursor),
+                json!(limit),
+                json!(descending_order)
+            ],
+        });
+
+        let response = self.client.post(self.url.clone()).json(&request_body).send().await?;
+
+        let body: RawRpcResponse<TransactionBlocksPage> = response.json().await?;
+        body.into_result()
+    }
+}

--- a/crates/etopay-wallet/src/rebased/rpc/mod.rs
+++ b/crates/etopay-wallet/src/rebased/rpc/mod.rs
@@ -1,6 +1,7 @@
 mod coin;
 mod errors;
 mod governance;
+mod indexer;
 mod read;
 mod transaction;
 mod write;
@@ -8,6 +9,7 @@ mod write;
 pub use coin::*;
 pub use errors::*;
 pub use governance::*;
+pub use indexer::*;
 pub use read::*;
 pub use transaction::*;
 pub use write::*;

--- a/crates/etopay-wallet/src/wallet.rs
+++ b/crates/etopay-wallet/src/wallet.rs
@@ -1,5 +1,5 @@
 use super::error::Result;
-use crate::types::{CryptoAmount, GasCostEstimation, WalletTxInfo, WalletTxInfoList};
+use crate::types::{CryptoAmount, GasCostEstimation, WalletTxInfo};
 use async_trait::async_trait;
 use std::fmt::Debug;
 
@@ -80,7 +80,7 @@ pub trait WalletUser: Debug {
     /// # Errors
     ///
     /// This function can return an error if it cannot retrieve the list of wallet transactions.
-    async fn get_wallet_tx_list(&self, start: usize, limit: usize) -> Result<WalletTxInfoList>;
+    async fn get_wallet_tx_list(&self, start: usize, limit: usize) -> Result<Vec<String>>;
 
     /// Get detailed report of a particular transaction in the history
     ///

--- a/crates/etopay-wallet/src/wallet_evm.rs
+++ b/crates/etopay-wallet/src/wallet_evm.rs
@@ -2,7 +2,7 @@ use super::error::Result;
 use super::wallet::{TransactionIntent, WalletUser};
 use crate::MnemonicDerivationOption;
 use crate::error::WalletError;
-use crate::types::{CryptoAmount, GasCostEstimation, WalletTxInfo, WalletTxInfoList, WalletTxStatus};
+use crate::types::{CryptoAmount, GasCostEstimation, WalletTxInfo, WalletTxStatus};
 use alloy::eips::BlockNumberOrTag;
 use alloy::network::{Ethereum, EthereumWallet, TransactionBuilder};
 use alloy::rpc::types::TransactionRequest;
@@ -261,7 +261,7 @@ impl WalletUser for WalletImplEvm {
     // The network does not provide information about historical transactions
     // (they can be retrieved manually, but this is a time-consuming process),
     // so the handling of this method is implemented at the SDK level.
-    async fn get_wallet_tx_list(&self, _start: usize, _limit: usize) -> Result<WalletTxInfoList> {
+    async fn get_wallet_tx_list(&self, _start: usize, _limit: usize) -> Result<Vec<String>> {
         Err(WalletError::WalletFeatureNotImplemented)
     }
 
@@ -432,7 +432,7 @@ impl WalletUser for WalletImplEvmErc20 {
     // The network does not provide information about historical transactions
     // (they can be retrieved manually, but this is a time-consuming process),
     // so the handling of this method is implemented at the SDK level.
-    async fn get_wallet_tx_list(&self, _start: usize, _limit: usize) -> Result<WalletTxInfoList> {
+    async fn get_wallet_tx_list(&self, _start: usize, _limit: usize) -> Result<Vec<String>> {
         Err(WalletError::WalletFeatureNotImplemented)
     }
 

--- a/crates/etopay-wallet/src/wallet_rebased.rs
+++ b/crates/etopay-wallet/src/wallet_rebased.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::ops::{Add, Sub};
 
 use super::error::{Result, WalletError};
@@ -7,8 +8,11 @@ use super::rebased::{
 };
 use super::wallet::{TransactionIntent, WalletUser};
 use crate::MnemonicDerivationOption;
-use crate::rebased::{CheckpointId, ErrorCode, IotaTransactionBlockEffects, Owner, TransactionKind};
-use crate::types::{CryptoAmount, GasCostEstimation, WalletTxInfo, WalletTxInfoList, WalletTxStatus};
+use crate::rebased::{
+    CheckpointId, ErrorCode, IndexerApi, IotaTransactionBlockEffects, IotaTransactionBlockResponseOptions,
+    IotaTransactionBlockResponseQuery, Owner, TransactionDigest, TransactionFilter, TransactionKind,
+};
+use crate::types::{CryptoAmount, GasCostEstimation, WalletTxInfo, WalletTxStatus};
 use async_trait::async_trait;
 use bip39::Mnemonic;
 use chrono::{TimeZone, Utc};
@@ -217,7 +221,57 @@ impl WalletUser for WalletImplIotaRebased {
         Ok(poll_response.digest.to_string())
     }
 
-    async fn get_wallet_tx_list(&self, start: usize, limit: usize) -> Result<WalletTxInfoList> {
+    async fn get_wallet_tx_list(&self, start: usize, limit: usize) -> Result<Vec<String>> {
+        // use the indexer api to query for all incoming and outgoing transactions:
+
+        let addr = self.keystore.addresses()[0];
+
+        log::info!("Querying transactions for address: {}", addr);
+
+        let txs_from = self
+            .client
+            .query_transaction_blocks(
+                IotaTransactionBlockResponseQuery {
+                    filter: Some(TransactionFilter::FromAddress(addr)),
+
+                    // includes only the digest
+                    options: Some(IotaTransactionBlockResponseOptions::default()),
+                },
+                None,       // No cursor (start from beginning)
+                Some(25),   // No limit (MAX limit)
+                Some(true), // descending, newest first
+            )
+            .await?;
+
+        let txs_to = self
+            .client
+            .query_transaction_blocks(
+                IotaTransactionBlockResponseQuery {
+                    filter: Some(TransactionFilter::ToAddress(addr)),
+
+                    // includes only the digest
+                    options: Some(IotaTransactionBlockResponseOptions::default()),
+                },
+                None,       // No cursor (start from beginning)
+                Some(25),   // No limit (MAX limit)
+                Some(true), // descending, newest first
+            )
+            .await?;
+
+        // merge them all into a single list, drop duplicates
+        let transaction_digests: HashSet<TransactionDigest> = txs_from
+            .data
+            .into_iter()
+            .chain(txs_to.data.into_iter())
+            .map(|t| t.digest)
+            .collect();
+
+        log::info!("Digests: {:#?}", transaction_digests);
+
+        // convert into a list, sort by hash to make the list stable (not sorted by time!)
+        // TODO: return the list of hashes and merge it in the outer logic? (tx info can then be
+        // queried using get_wallet_tx below for any new transactions)
+
         Err(WalletError::WalletFeatureNotImplemented)
     }
 

--- a/crates/etopay-wallet/src/wallet_rebased.rs
+++ b/crates/etopay-wallet/src/wallet_rebased.rs
@@ -266,13 +266,10 @@ impl WalletUser for WalletImplIotaRebased {
             .map(|t| t.digest)
             .collect();
 
-        log::info!("Digests: {:#?}", transaction_digests);
-
-        // convert into a list, sort by hash to make the list stable (not sorted by time!)
-        // TODO: return the list of hashes and merge it in the outer logic? (tx info can then be
-        // queried using get_wallet_tx below for any new transactions)
-
-        Err(WalletError::WalletFeatureNotImplemented)
+        Ok(transaction_digests
+            .iter()
+            .map(|d| d.to_string())
+            .collect::<Vec<String>>())
     }
 
     async fn get_wallet_tx(&self, tx_hash: &str) -> Result<WalletTxInfo> {

--- a/crates/etopay-wallet/src/wallet_tx_sort.rs
+++ b/crates/etopay-wallet/src/wallet_tx_sort.rs
@@ -1,0 +1,90 @@
+use chrono::DateTime;
+use std::cmp::Ordering;
+
+use crate::types::WalletTxInfo;
+
+pub fn sort_by_date(transactions: &mut [WalletTxInfo]) {
+    transactions.sort_by(|a, b| {
+        let a_date = DateTime::parse_from_rfc3339(&a.date);
+        let b_date = DateTime::parse_from_rfc3339(&b.date);
+
+        match (a_date, b_date) {
+            (Ok(a_dt), Ok(b_dt)) => a_dt.cmp(&b_dt),
+            // fallback if parsing fails: put unparsable dates at the end
+            (Ok(_), Err(_)) => Ordering::Less,
+            (Err(_), Ok(_)) => Ordering::Greater,
+            (Err(_), Err(_)) => Ordering::Equal,
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::types::{CryptoAmount, WalletTxInfo};
+
+    use super::sort_by_date;
+
+    fn mock_transaction(date: &str) -> WalletTxInfo {
+        WalletTxInfo {
+            date: String::from(date),
+            block_number_hash: None,
+            transaction_hash: String::from("tx_hash"),
+            sender: "Satoshi".to_string(),
+            receiver: "Bob".to_string(),
+            amount: CryptoAmount::from(1),
+            network_key: String::from("network"),
+            status: crate::types::WalletTxStatus::Pending,
+            explorer_url: None,
+        }
+    }
+
+    #[test]
+    fn test_should_sort_by_date() {
+        // Given
+        let mut transactions = vec![
+            mock_transaction("2025-05-29T08:37:15.183+00:00"),
+            mock_transaction("2025-05-29T08:37:14.183+00:00"),
+            mock_transaction("2025-05-29T08:37:13.183+00:00"),
+            mock_transaction("2025-05-29T08:37:16.183+00:00"),
+            mock_transaction("2025-05-29T08:37:12.183+00:00"),
+        ];
+
+        let expected = vec![
+            mock_transaction("2025-05-29T08:37:12.183+00:00"),
+            mock_transaction("2025-05-29T08:37:13.183+00:00"),
+            mock_transaction("2025-05-29T08:37:14.183+00:00"),
+            mock_transaction("2025-05-29T08:37:15.183+00:00"),
+            mock_transaction("2025-05-29T08:37:16.183+00:00"),
+        ];
+
+        // When
+        sort_by_date(&mut transactions);
+
+        // Then
+        assert_eq!(expected, transactions);
+    }
+
+    #[test]
+    fn test_should_put_unparsable_dates_at_the_end() {
+        // Given
+        let mut transactions = vec![
+            mock_transaction("2026-05-29"),
+            mock_transaction("invalid date"),
+            mock_transaction("2025-05-29T08:37:14.183+00:00"),
+            mock_transaction("2025-05-29T08:37:13.183+00:00"),
+        ];
+
+        let expected = vec![
+            mock_transaction("2025-05-29T08:37:13.183+00:00"),
+            mock_transaction("2025-05-29T08:37:14.183+00:00"),
+            mock_transaction("2026-05-29"),
+            mock_transaction("invalid date"),
+        ];
+
+        // When
+        sort_by_date(&mut transactions);
+
+        // Then
+        assert_eq!(expected, transactions);
+    }
+}

--- a/crates/etopay-wallet/src/wallet_tx_sort.rs
+++ b/crates/etopay-wallet/src/wallet_tx_sort.rs
@@ -9,7 +9,7 @@ pub fn sort_by_date(transactions: &mut [WalletTxInfo]) {
         let b_date = DateTime::parse_from_rfc3339(&b.date);
 
         match (a_date, b_date) {
-            (Ok(a_dt), Ok(b_dt)) => a_dt.cmp(&b_dt),
+            (Ok(a_dt), Ok(b_dt)) => b_dt.cmp(&a_dt),
             // fallback if parsing fails: put unparsable dates at the end
             (Ok(_), Err(_)) => Ordering::Less,
             (Err(_), Ok(_)) => Ordering::Greater,
@@ -50,11 +50,11 @@ mod tests {
         ];
 
         let expected = vec![
-            mock_transaction("2025-05-29T08:37:12.183+00:00"),
-            mock_transaction("2025-05-29T08:37:13.183+00:00"),
-            mock_transaction("2025-05-29T08:37:14.183+00:00"),
-            mock_transaction("2025-05-29T08:37:15.183+00:00"),
             mock_transaction("2025-05-29T08:37:16.183+00:00"),
+            mock_transaction("2025-05-29T08:37:15.183+00:00"),
+            mock_transaction("2025-05-29T08:37:14.183+00:00"),
+            mock_transaction("2025-05-29T08:37:13.183+00:00"),
+            mock_transaction("2025-05-29T08:37:12.183+00:00"),
         ];
 
         // When
@@ -75,8 +75,8 @@ mod tests {
         ];
 
         let expected = vec![
-            mock_transaction("2025-05-29T08:37:13.183+00:00"),
             mock_transaction("2025-05-29T08:37:14.183+00:00"),
+            mock_transaction("2025-05-29T08:37:13.183+00:00"),
             mock_transaction("2026-05-29"),
             mock_transaction("invalid date"),
         ];

--- a/sdk/examples/19_get_wallet_tx_list.rs
+++ b/sdk/examples/19_get_wallet_tx_list.rs
@@ -21,7 +21,9 @@ async fn main() {
     )
     .await
     .unwrap();
-    sdk.create_wallet_from_new_mnemonic(&user.pin).await.unwrap();
+    sdk.create_wallet_from_existing_mnemonic(&user.pin, &user.mnemonic)
+        .await
+        .unwrap();
 
     // Fetch networks from backend
     let _ = sdk.get_networks().await.unwrap();

--- a/sdk/examples/19_get_wallet_tx_list.rs
+++ b/sdk/examples/19_get_wallet_tx_list.rs
@@ -21,12 +21,7 @@ async fn main() {
     )
     .await
     .unwrap();
-    // sdk.create_wallet_from_existing_mnemonic(&user.pin, &user.mnemonic)
-    //     .await
-    //     .unwrap();
-
-    let custom_mnemonic = "execute best inhale impulse ripple element oval visual language shaft service token venture glove possible tumble erode bless ice feature dynamic poem daring tilt";
-    sdk.create_wallet_from_existing_mnemonic(&user.pin, &custom_mnemonic)
+    sdk.create_wallet_from_existing_mnemonic(&user.pin, &user.mnemonic)
         .await
         .unwrap();
 

--- a/sdk/examples/19_get_wallet_tx_list.rs
+++ b/sdk/examples/19_get_wallet_tx_list.rs
@@ -21,7 +21,12 @@ async fn main() {
     )
     .await
     .unwrap();
-    sdk.create_wallet_from_existing_mnemonic(&user.pin, &user.mnemonic)
+    // sdk.create_wallet_from_existing_mnemonic(&user.pin, &user.mnemonic)
+    //     .await
+    //     .unwrap();
+
+    let custom_mnemonic = "execute best inhale impulse ripple element oval visual language shaft service token venture glove possible tumble erode bless ice feature dynamic poem daring tilt";
+    sdk.create_wallet_from_existing_mnemonic(&user.pin, &custom_mnemonic)
         .await
         .unwrap();
 

--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -539,11 +539,7 @@ impl Sdk {
                 log::debug!("Digests: {:#?}", transaction_hashes);
                 for hash in transaction_hashes {
                     // check if transaction is already in the list (not very efficient to do a linear search, but good enough for now)
-                    if wallet_transactions
-                        .iter()
-                        .find(|t| t.transaction_hash == hash)
-                        .is_some()
-                    {
+                    if wallet_transactions.iter().any(|t| t.transaction_hash == hash) {
                         continue;
                     }
 

--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -1276,7 +1276,11 @@ mod tests {
 
                 let mut mock_wallet_manager = MockWalletManager::new();
                 mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
-                    let mock_wallet_user = MockWalletUser::new();
+                    let mut mock_wallet_user = MockWalletUser::new();
+                    mock_wallet_user
+                        .expect_get_wallet_tx_list()
+                        .once()
+                        .returning(|_, _| Ok(vec![]));
                     Ok(WalletBorrow::from(mock_wallet_user))
                 });
                 sdk.active_user = Some(crate::types::users::ActiveUser {
@@ -1438,6 +1442,10 @@ mod tests {
         mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
             let mut mock_wallet_user = MockWalletUser::new();
             mock_wallet_user
+                .expect_get_wallet_tx_list()
+                .once()
+                .returning(|_, _| Ok(vec![]));
+            mock_wallet_user
                 .expect_get_wallet_tx()
                 .once()
                 .with(eq(String::from("2"))) // WalletTxInfo.transaction_id = 2
@@ -1537,6 +1545,10 @@ mod tests {
         let mut mock_wallet_manager = MockWalletManager::new();
         mock_wallet_manager.expect_try_get().returning(move |_, _, _, _, _, _| {
             let mut mock_wallet_user = MockWalletUser::new();
+            mock_wallet_user
+                .expect_get_wallet_tx_list()
+                .once()
+                .returning(|_, _| Ok(vec![]));
             mock_wallet_user.expect_get_wallet_tx().never();
             Ok(WalletBorrow::from(mock_wallet_user))
         });

--- a/sdk/src/core/wallet.rs
+++ b/sdk/src/core/wallet.rs
@@ -1626,7 +1626,7 @@ mod tests {
         };
 
         let wallet_transactions = vec![tx_3.clone(), tx_1.clone(), tx_2.clone()];
-        let expected = vec![tx_1, tx_2, tx_3];
+        let expected = vec![tx_3, tx_2, tx_1];
 
         let mut mock_user_repo = MockUserRepo::new();
         mock_user_repo.expect_get().returning(move |_| {


### PR DESCRIPTION
## Motivation and Context

We want to automatically discover the incoming and outgoing transactions for each address, which we can do using an extended RPC api for the IOTA Rebased nodes 💯 

## Summary

Provide a short summary of changes in this pull request.

- Add RPC call to list transactions based on to / from addresses.
- Add logic to call the `WalletUser::get_wallet_tx_list` function (which now returns a vector of transaction hashes) and incorporate this information directly in the local list of transactions.
- sort the transaction list based on timestamp (we will need to store the date as some numeric, eg. UTC, for that to work)

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
