### PR TITLE
fix: JSON.stringify BigInt error in wasm example 19-get_wallet_tx_list

### DIFF
--- a/bindings/wasm/examples/19-get_wallet_tx_list.ts
+++ b/bindings/wasm/examples/19-get_wallet_tx_list.ts
@@ -20,7 +20,13 @@ async function main() {
     sdk.setNetwork("iota_rebased_testnet");
 
     let transactions = await sdk.getWalletTransactionList(PIN, 0, 10);  // Get the transaction list
-    console.log("Wallet transactions list: " + JSON.stringify(transactions));
+
+    const callback = (_key, value) => typeof value === "bigint" ? value.toString() : value;
+
+    console.log(
+        "Wallet transactions list: " +
+        JSON.stringify(transactions, callback)
+    );
 }
 
 main();

--- a/bindings/wasm/src/types.rs
+++ b/bindings/wasm/src/types.rs
@@ -256,7 +256,7 @@ pub struct WalletTxInfo {
     /// Contains block number / id
     pub block_number: Option<String>,
     /// Contains block hash
-    pub block_hash: Option<String>,
+    pub block_number: Option<u64>,
     /// transaction id for particular transaction
     pub transaction_hash: String,
     /// The sender of the transaction
@@ -282,7 +282,7 @@ impl From<sdk::types::WalletTxInfo> for WalletTxInfo {
     fn from(value: sdk::types::WalletTxInfo) -> Self {
         Self {
             date: value.date,
-            block_number: value.block_number_hash.as_ref().map(|b| b.0.to_string()),
+            block_number: value.block_number_hash.as_ref().map(|b| b.0),
             block_hash: value.block_number_hash.map(|b| b.1),
             transaction_hash: value.transaction_hash,
             sender: value.sender,

--- a/bindings/wasm/src/types.rs
+++ b/bindings/wasm/src/types.rs
@@ -254,7 +254,7 @@ pub struct WalletTxInfo {
     /// Tx creation date, if available
     pub date: String,
     /// Contains block number / id
-    pub block_number: Option<u64>,
+    pub block_number: Option<String>,
     /// Contains block hash
     pub block_hash: Option<String>,
     /// transaction id for particular transaction
@@ -282,7 +282,7 @@ impl From<sdk::types::WalletTxInfo> for WalletTxInfo {
     fn from(value: sdk::types::WalletTxInfo) -> Self {
         Self {
             date: value.date,
-            block_number: value.block_number_hash.as_ref().map(|b| b.0),
+            block_number: value.block_number_hash.as_ref().map(|b| b.0.to_string()),
             block_hash: value.block_number_hash.map(|b| b.1),
             transaction_hash: value.transaction_hash,
             sender: value.sender,

--- a/bindings/wasm/src/types.rs
+++ b/bindings/wasm/src/types.rs
@@ -254,9 +254,9 @@ pub struct WalletTxInfo {
     /// Tx creation date, if available
     pub date: String,
     /// Contains block number / id
-    pub block_number: Option<String>,
-    /// Contains block hash
     pub block_number: Option<u64>,
+    /// Contains block hash
+    pub block_hash: Option<String>,
     /// transaction id for particular transaction
     pub transaction_hash: String,
     /// The sender of the transaction


### PR DESCRIPTION
## Motivation and Context

The latest changes caused an error:

```
console.log("Wallet transactions list: " + JSON.stringify(transactions));
                                                         ^
TypeError: JSON.stringify cannot serialize BigInt.
```

This pull request is to fix wasm `19-get_wallet_tx_list.ts` example.

## Summary

We chose to use a callback with `JSON.stringify` to fix the problem.

## Checklist

Please ensure that your PR meets the following requirements:

### General

- [ ] Code follows project style and guidelines.
- [ ] No redundant or duplicate code.
- [ ] No added new dependencies without clear justification and approval.

### Documentation

- [ ] Added/updated relevant documentation (e.g., README, inline comments).
- [ ] Added a CHANGELOG entry for major changes.

### Testing

- [ ] Added relevant test cases, leveraging tools like `rstest` or similar for reusable tests.
- [ ] Tests pass locally.

### Build & CI/CD

- [ ] Confirmed no CI/CD pipeline issues.
- [ ] Updated build scripts where necessary.

## Comments to Reviewer

Please provide any comments or points of consideration for the reviewers, such as specific areas of focus, potential edge cases, or context that would aid the review process.

### Reviewer Responsibilities

- [ ] Code adheres to style and guidelines.
- [ ] All tests are appropriately covered and they pass.
- [ ] Consider performance and/or security impacts.
- [ ] Constructive feedback is provided.
